### PR TITLE
Add apply_vbd configuration for CertifScripts

### DIFF
--- a/src/pseudospectra/rigorous_contour.jl
+++ b/src/pseudospectra/rigorous_contour.jl
@@ -122,7 +122,7 @@ function _certify_circle(T, λ, r, N)
         K = svd(T - z * I)
         z_ball = Ball(z, pearl_radius)
 
-        bound = _certify_svd(BallMatrix(T) - z_ball * I, K)[end]
+        bound = _certify_svd(BallMatrix(T) - z_ball * I, K; apply_vbd = true).singular_values[end]
         push!(out_bound, bound)
         push!(out_radiuses, pearl_radius)
     end
@@ -169,7 +169,7 @@ function _compute_exclusion_set(T, r; max_steps, rel_steps, λ = 0 + im * 0)
 
         # we certify in a ball around z_old
         z_ball = Ball(z_old, r_guaranteed)
-        bound = _certify_svd(BallMatrix(T) - z_ball * I, K)[end]
+        bound = _certify_svd(BallMatrix(T) - z_ball * I, K; apply_vbd = true).singular_values[end]
         push!(out_bound, bound)
         push!(out_radiuses, r_guaranteed)
         #print("test")
@@ -300,7 +300,7 @@ function _compute_enclosure_eigval(T, λ, ϵ; max_initial_newton, max_steps, rel
         # we certify the SVD on a ball around z_old
 
         z_ball = Ball(z_old, r_guaranteed)
-        bound = _certify_svd(BallMatrix(T) - z_ball * I, K)[end]
+        bound = _certify_svd(BallMatrix(T) - z_ball * I, K; apply_vbd = true).singular_values[end]
         push!(out_bound, bound)
         push!(radiuses, r_guaranteed)
 

--- a/test/test_certification/test_certifscripts.jl
+++ b/test/test_certification/test_certifscripts.jl
@@ -9,24 +9,32 @@ using BallArithmetic
     @test !isempty(result.certification_log)
     @test result.minimum_singular_value > 0
     @test result.resolvent_original >= result.resolvent_schur
+
+    result_no_vbd = BallArithmetic.CertifScripts.run_certification(A, circle; η = 0.9,
+        check_interval = 4, log_io = IOBuffer(), apply_vbd = false)
+    @test !isempty(result_no_vbd.certification_log)
+    @test result_no_vbd.minimum_singular_value > 0
 end
 
 @testset "CertifScripts distributed" begin
     using Distributed
     circle = BallArithmetic.CertifScripts.CertificationCircle(0.0, 0.25; samples = 8)
     A = BallArithmetic.BallMatrix(Matrix{ComplexF64}(I, 2, 2))
-    result = BallArithmetic.CertifScripts.run_certification(A, circle, 1; η = 0.9, check_interval = 4, log_io = IOBuffer(), channel_capacity = 4)
+    result = BallArithmetic.CertifScripts.run_certification(A, circle, 1; η = 0.9, check_interval = 4,
+        log_io = IOBuffer(), channel_capacity = 4, apply_vbd = false)
     @test result.circle == circle
     @test !isempty(result.certification_log)
 
     pids = addprocs(1)
     pool = WorkerPool(pids)
     try
-        pooled_result = BallArithmetic.CertifScripts.run_certification(A, circle, pool; η = 0.9, check_interval = 4, log_io = IOBuffer(), channel_capacity = 4)
+        pooled_result = BallArithmetic.CertifScripts.run_certification(A, circle, pool; η = 0.9, check_interval = 4,
+            log_io = IOBuffer(), channel_capacity = 4)
         @test pooled_result.circle == circle
         @test !isempty(pooled_result.certification_log)
 
-        reuse_result = BallArithmetic.CertifScripts.run_certification(A, circle, pool; η = 0.9, check_interval = 4, log_io = IOBuffer(), channel_capacity = 4)
+        reuse_result = BallArithmetic.CertifScripts.run_certification(A, circle, pool; η = 0.9, check_interval = 4,
+            log_io = IOBuffer(), channel_capacity = 4, apply_vbd = false)
         @test reuse_result.circle == circle
         @test !isempty(reuse_result.certification_log)
     finally


### PR DESCRIPTION
## Summary
- allow CertifScripts to toggle the Miyajima preconditioner when sampling and share the setting with distributed workers
- update pseudospectra helpers to use the new configuration when certifying singular values
- extend certification tests to exercise the apply_vbd flag in serial and distributed modes

## Testing
- `julia --project -e 'using Pkg; Pkg.test("BallArithmetic"; test_args=["pseudospectra","certification"])'`


------
https://chatgpt.com/codex/tasks/task_e_68f9424eea1883249555c43fad9a7df8