### PR TITLE
Add array-like interface to RigorousSVDResult

### DIFF
--- a/src/svd/svd.jl
+++ b/src/svd/svd.jl
@@ -28,6 +28,15 @@ struct RigorousSVDResult{UT, ST, ΣT, VT, ET, RT, VBDT}
     block_diagonalisation::VBDT
 end
 
+Base.size(result::RigorousSVDResult) = size(result.singular_values)
+Base.length(result::RigorousSVDResult) = length(result.singular_values)
+Base.firstindex(result::RigorousSVDResult) = firstindex(result.singular_values)
+Base.lastindex(result::RigorousSVDResult) = lastindex(result.singular_values)
+Base.lastindex(result::RigorousSVDResult, i::Int) = lastindex(result.singular_values, i)
+Base.getindex(result::RigorousSVDResult, inds...) = getindex(result.singular_values, inds...)
+Base.iterate(result::RigorousSVDResult) = iterate(result.singular_values)
+Base.iterate(result::RigorousSVDResult, state) = iterate(result.singular_values, state)
+
 """
     rigorous_svd(A::BallMatrix; apply_vbd = true)
 


### PR DESCRIPTION
## Summary
- forward indexing and iteration on `RigorousSVDResult` to the underlying `singular_values` vector so callers can continue to treat the result like a collection of enclosures

## Testing
- `julia --project -e 'using Pkg; Pkg.test("BallArithmetic"; test_args=["pseudospectra"])'` *(fails: interrupted after extended precompilation; pseudospectra tests completed successfully before interruption)*

------
https://chatgpt.com/codex/tasks/task_e_68f9568f95e88324adc5ee838cc36a3a