### PR TITLE
Add structured eigenvalue enclosure results

### DIFF
--- a/src/BallArithmetic.jl
+++ b/src/BallArithmetic.jl
@@ -83,6 +83,8 @@ include("norm_bounds/oishi_triangular.jl")
 export upper_bound_L1_opnorm, upper_bound_L2_opnorm, upper_bound_L_inf_opnorm
 include("eigenvalues/gev.jl")
 include("eigenvalues/upper_bound_spectral.jl")
+export RigorousGeneralizedEigenvaluesResult, RigorousEigenvaluesResult,
+    rigorous_generalized_eigenvalues, rigorous_eigenvalues, gevbox, evbox
 include("svd/singular_gerschgorin.jl")
 include("svd/miyajima_vbd.jl")
 include("svd/svd.jl")

--- a/src/eigenvalues/gev.jl
+++ b/src/eigenvalues/gev.jl
@@ -1,89 +1,223 @@
-
 # Implementing Theorem 2 Miyajima
 # Numerical enclosure for each eigenvalue in generalized eigenvalue problem
-"""
-    gevbox(A::BallMatrix{T}, B::BallMatrix{T})
 
-Compute rigorous enclosure of each eigenvalue in generalized eigenvalue problem
-following Ref. [Miyajima2012](@cite)
+"""
+    RigorousGeneralizedEigenvaluesResult
+
+Container returned by [`rigorous_generalized_eigenvalues`](@ref) bundling
+the midpoint eigenvector factorisation, the certified eigenvalue
+enclosures, and the norm bounds underpinning their verification.
+Besides behaving like the underlying vector of eigenvalue balls, the
+struct exposes the interval residual, the projected residual used in the
+Miyajima certification, and the coupling defect of the left action
+(`left_action * B * right_vectors - I`).
+"""
+struct RigorousGeneralizedEigenvaluesResult{XT, YT, ΛT, ΛMT, ET, RT, BT}
+    """Ball enclosure of the right eigenvectors."""
+    right_vectors::XT
+    """Ball enclosure of the left action verifying `left_action * B * right_vectors ≈ I`."""
+    left_action::YT
+    """Certified eigenvalues returned as floating-point balls."""
+    eigenvalues::ΛT
+    """Diagonal ball matrix containing the eigenvalue enclosure."""
+    Λ::ΛMT
+    """Residual enclosure `A * right_vectors - B * right_vectors * Λ`."""
+    residual::ET
+    """Upper bound on `‖residual‖∞`."""
+    residual_norm::RT
+    """Upper bound on `‖left_action * residual‖∞` (projected residual)."""
+    projected_residual_norm::RT
+    """Coupling defect enclosure `left_action * B * right_vectors - I`."""
+    coupling_defect::BT
+    """Upper bound on `‖coupling_defect‖∞`."""
+    coupling_defect_norm::RT
+end
+
+Base.size(result::RigorousGeneralizedEigenvaluesResult) = size(result.eigenvalues)
+Base.length(result::RigorousGeneralizedEigenvaluesResult) = length(result.eigenvalues)
+Base.firstindex(result::RigorousGeneralizedEigenvaluesResult) = firstindex(result.eigenvalues)
+Base.lastindex(result::RigorousGeneralizedEigenvaluesResult) = lastindex(result.eigenvalues)
+Base.lastindex(result::RigorousGeneralizedEigenvaluesResult, i::Int) =
+    lastindex(result.eigenvalues, i)
+Base.getindex(result::RigorousGeneralizedEigenvaluesResult, inds...) =
+    getindex(result.eigenvalues, inds...)
+Base.iterate(result::RigorousGeneralizedEigenvaluesResult) = iterate(result.eigenvalues)
+Base.iterate(result::RigorousGeneralizedEigenvaluesResult, state) =
+    iterate(result.eigenvalues, state)
+
+"""
+    RigorousEigenvaluesResult
+
+Container returned by [`rigorous_eigenvalues`](@ref) bundling the
+midpoint eigenvector factorisation, the certified eigenvalue enclosures,
+and the norm bounds underpinning their verification. Besides behaving
+like the underlying vector of eigenvalue balls, the struct exposes the
+interval residual, the projected residual used in the Miyajima
+certification, and the inverse defect (`inverse * vectors - I`).
+"""
+struct RigorousEigenvaluesResult{VT, YT, ΛT, ΛMT, ET, RT, BT}
+    """Ball enclosure of the eigenvectors."""
+    vectors::VT
+    """Ball enclosure of the inverse of `vectors`."""
+    inverse::YT
+    """Certified eigenvalues returned as floating-point balls."""
+    eigenvalues::ΛT
+    """Diagonal ball matrix containing the eigenvalue enclosure."""
+    Λ::ΛMT
+    """Residual enclosure `A * vectors - vectors * Λ`."""
+    residual::ET
+    """Upper bound on `‖residual‖∞`."""
+    residual_norm::RT
+    """Upper bound on `‖inverse * residual‖∞` (projected residual)."""
+    projected_residual_norm::RT
+    """Inverse defect enclosure `inverse * vectors - I`."""
+    inverse_defect::BT
+    """Upper bound on `‖inverse_defect‖∞`."""
+    inverse_defect_norm::RT
+end
+
+Base.size(result::RigorousEigenvaluesResult) = size(result.eigenvalues)
+Base.length(result::RigorousEigenvaluesResult) = length(result.eigenvalues)
+Base.firstindex(result::RigorousEigenvaluesResult) = firstindex(result.eigenvalues)
+Base.lastindex(result::RigorousEigenvaluesResult) = lastindex(result.eigenvalues)
+Base.lastindex(result::RigorousEigenvaluesResult, i::Int) =
+    lastindex(result.eigenvalues, i)
+Base.getindex(result::RigorousEigenvaluesResult, inds...) =
+    getindex(result.eigenvalues, inds...)
+Base.iterate(result::RigorousEigenvaluesResult) = iterate(result.eigenvalues)
+Base.iterate(result::RigorousEigenvaluesResult, state) =
+    iterate(result.eigenvalues, state)
+
+"""
+    rigorous_generalized_eigenvalues(A::BallMatrix, B::BallMatrix)
+
+Compute rigorous enclosures for the eigenvalues of the generalised
+problem `A * x = λ * B * x`, following Ref. [Miyajima2012](@cite).  The
+returned [`RigorousGeneralizedEigenvaluesResult`](@ref) exposes both the
+interval enclosures and the norm bounds used during certification.
 
 # References
 
 * [Miyajima2012](@cite) Miyajima, JCAM 246, 9 (2012)
 """
-function gevbox(A::BallMatrix{T}, B::BallMatrix{T}) where {T}
+function rigorous_generalized_eigenvalues(A::BallMatrix{T}, B::BallMatrix{T}) where {T}
     gev = eigen(A.c, B.c)
-    return _certify_gev(A, B, gev)
-end
-
-function _certify_gev(A::BallMatrix{T}, B::BallMatrix{T}, gev::GeneralizedEigen) where {T}
-    X = gev.vectors
-    Y = inv(B.c * X)
-
-    bX = BallMatrix(X)
-    bY = BallMatrix(Y)
-
-    S = bY * B * bX - I
-    normS = upper_bound_L_inf_opnorm(S)
-    @debug "norm S" normS
-    @assert normS<1 "It is not possible to verify the eigenvalues with this precision"
-
-    bD = BallMatrix(Diagonal(gev.values))
-
-    R = bY * (A * bX - B * bX * bD)
-    normR = upper_bound_L_inf_opnorm(R)
-    @debug "norm R" normR
-
-    den_up = @down (1.0 - normS)
-    eps = @up normR / den_up
-
-    return [Ball(lam, eps) for lam in gev.values]
+    return _certify_generalized_eigenvalues(A, B, gev)
 end
 
 """
-    evbox(A::BallMatrix{T})
+    gevbox(A::BallMatrix{T}, B::BallMatrix{T})
 
-Compute rigorous enclosure of each eigenvalue following Ref. [Miyajima2012](@cite)
+Backward-compatible wrapper returning only the vector of eigenvalue
+enclosures produced by [`rigorous_generalized_eigenvalues`](@ref).
+"""
+function gevbox(A::BallMatrix{T}, B::BallMatrix{T}) where {T}
+    result = rigorous_generalized_eigenvalues(A, B)
+    return result.eigenvalues
+end
+
+function _certify_generalized_eigenvalues(A::BallMatrix{T}, B::BallMatrix{T},
+        gev::GeneralizedEigen) where {T}
+    X_mid = gev.vectors
+    Y_mid = inv(B.c * X_mid)
+
+    bX = BallMatrix(X_mid)
+    bY = BallMatrix(Y_mid)
+
+    coupling_defect = bY * B * bX - I
+    coupling_defect_norm = upper_bound_L_inf_opnorm(coupling_defect)
+    @debug "norm coupling defect" coupling_defect_norm
+    @assert coupling_defect_norm < 1 "It is not possible to verify the eigenvalues with this precision"
+
+    D_mid = BallMatrix(Diagonal(gev.values))
+    projected_residual_mid = bY * (A * bX - B * bX * D_mid)
+    projected_residual_norm_mid = upper_bound_L_inf_opnorm(projected_residual_mid)
+    @debug "projected residual norm" projected_residual_norm_mid
+
+    den_up = @down (one(T) - coupling_defect_norm)
+    eps = @up projected_residual_norm_mid / den_up
+
+    eigenvalues = [Ball(lam, eps) for lam in gev.values]
+    Λ = _diagonal_ball_matrix(eigenvalues)
+
+    residual = A * bX - B * bX * Λ
+    residual_norm = upper_bound_L_inf_opnorm(residual)
+    projected_residual = bY * residual
+    projected_residual_norm = upper_bound_L_inf_opnorm(projected_residual)
+
+    return RigorousGeneralizedEigenvaluesResult(bX, bY, eigenvalues, Λ,
+        residual, residual_norm, projected_residual_norm,
+        coupling_defect, coupling_defect_norm)
+end
+
+"""
+    rigorous_eigenvalues(A::BallMatrix)
+
+Compute rigorous enclosures for the eigenvalues of `A`, following
+Ref. [Miyajima2012](@cite).  The returned
+[`RigorousEigenvaluesResult`](@ref) exposes both the interval enclosures
+and the norm bounds used during certification.
+
 TODO: Using Miyajima's algorithm is overkill, may be worth using
 
 # References
 
 * [Miyajima2012](@cite) Miyajima, JCAM 246, 9 (2012)
 """
-function evbox(A::BallMatrix{T}) where {T}
+function rigorous_eigenvalues(A::BallMatrix{T}) where {T}
     gev = eigen(A.c)
-    return _certify_evbox(A, gev)
+    return _certify_eigenvalues(A, gev)
 end
 
-function _certify_evbox(A::BallMatrix{T}, gev::Eigen) where {T}
-    X = gev.vectors
-    Y = inv(X)
+"""
+    evbox(A::BallMatrix{T})
 
-    bX = BallMatrix(X)
-    bY = BallMatrix(Y)
+Backward-compatible wrapper returning only the vector of eigenvalue
+enclosures produced by [`rigorous_eigenvalues`](@ref).
+"""
+function evbox(A::BallMatrix{T}) where {T}
+    result = rigorous_eigenvalues(A)
+    return result.eigenvalues
+end
 
-    S = bY * bX - I
-    normS = upper_bound_L_inf_opnorm(S)
-    @debug "norm S" normS
-    @assert normS<1 "It is not possible to verify the eigenvalues with this precision",
-    normS,
-    norm(X, 2),
-    norm(Y, 2)
+function _certify_eigenvalues(A::BallMatrix{T}, gev::Eigen) where {T}
+    X_mid = gev.vectors
+    Y_mid = inv(X_mid)
 
-    bD = BallMatrix(Diagonal(gev.values))
+    bX = BallMatrix(X_mid)
+    bY = BallMatrix(Y_mid)
+
+    inverse_defect = bY * bX - I
+    inverse_defect_norm = upper_bound_L_inf_opnorm(inverse_defect)
+    @debug "norm inverse defect" inverse_defect_norm
+    @assert inverse_defect_norm < 1 "It is not possible to verify the eigenvalues with this precision",
+        inverse_defect_norm,
+        norm(X_mid, 2),
+        norm(Y_mid, 2)
+
+    D_mid = BallMatrix(Diagonal(gev.values))
 
     # probably something better can be done here
     # since this is not GEV, but only EV
     # need to look better at Miyajima
     # https://www.sciencedirect.com/science/article/pii/S037704270900795X
 
-    R = bY * (A * bX - bX * bD)
+    projected_residual_mid = bY * (A * bX - bX * D_mid)
 
-    normR = upper_bound_L_inf_opnorm(R)
-    @debug "norm R" normR
+    projected_residual_norm_mid = upper_bound_L_inf_opnorm(projected_residual_mid)
+    @debug "projected residual norm" projected_residual_norm_mid
 
-    den_up = @down (1.0 - normS)
-    eps = @up normR / den_up
+    den_up = @down (one(T) - inverse_defect_norm)
+    eps = @up projected_residual_norm_mid / den_up
 
-    return [Ball(lam, eps) for lam in gev.values]
+    eigenvalues = [Ball(lam, eps) for lam in gev.values]
+    Λ = _diagonal_ball_matrix(eigenvalues)
+
+    residual = A * bX - bX * Λ
+    residual_norm = upper_bound_L_inf_opnorm(residual)
+    projected_residual = bY * residual
+    projected_residual_norm = upper_bound_L_inf_opnorm(projected_residual)
+
+    return RigorousEigenvaluesResult(bX, bY, eigenvalues, Λ, residual,
+        residual_norm, projected_residual_norm, inverse_defect, inverse_defect_norm)
 end

--- a/test/test_eigen/test_eigen.jl
+++ b/test/test_eigen/test_eigen.jl
@@ -3,15 +3,27 @@
 
     A = BallMatrix(rand(256, 256))
 
+    gev_result = BallArithmetic.rigorous_generalized_eigenvalues(A, A)
     v = BallArithmetic.gevbox(A, A)
 
-    @test all([abs(v[i].c - 1.0) < v[i].r for i in 1:256])
+    @test gev_result isa BallArithmetic.RigorousGeneralizedEigenvaluesResult
+    @test gev_result.eigenvalues == v
+    @test gev_result[1] == v[1]
+    @test all(abs(gev_result[i].c - 1.0) < gev_result[i].r for i in 1:256)
+    @test gev_result.coupling_defect_norm >= zero(radtype(first(v)))
+    @test gev_result.projected_residual_norm >= zero(radtype(first(v)))
 
     bA = BallMatrix([125.0 0.00000001; 0.0 256.0])
 
     @test BallArithmetic.collatz_upper_bound(bA) >= 256.0
 
+    ev_result = BallArithmetic.rigorous_eigenvalues(bA)
     v = BallArithmetic.evbox(bA)
 
-    @test abs(v[1].c - 125.0) <= v[1].r
+    @test ev_result isa BallArithmetic.RigorousEigenvaluesResult
+    @test ev_result.eigenvalues == v
+    @test ev_result[1] == v[1]
+    @test abs(ev_result[1].c - 125.0) <= ev_result[1].r
+    @test ev_result.inverse_defect_norm >= zero(radtype(first(v)))
+    @test ev_result.projected_residual_norm >= zero(radtype(first(v)))
 end


### PR DESCRIPTION
## Summary
- add `RigorousGeneralizedEigenvaluesResult` and `RigorousEigenvaluesResult` containers that expose eigenvalue enclosures together with certification diagnostics
- expose new rigorous eigenvalue APIs and keep `gevbox`/`evbox` as thin wrappers for backward compatibility
- extend the eigenvalue tests to cover the new result structs and their array-like behaviour

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'`


------
https://chatgpt.com/codex/tasks/task_e_68f9669d8848832497bd2db3f6b2ccf3