### PR TITLE
Document Miyajima advanced kernels in docstrings

### DIFF
--- a/docs/src/API.md
+++ b/docs/src/API.md
@@ -35,8 +35,17 @@ BallArithmetic.NumericalTest.rounding_test
 
 ```@docs
 BallArithmetic.oishi_MMul
+```
+
+## Advanced API
+
+```@docs
 BallArithmetic._ccrprod
+BallArithmetic._ccrprod_prime
+BallArithmetic._ccr
 BallArithmetic._cr
 BallArithmetic._iprod
+BallArithmetic._iprod_right
 BallArithmetic._ciprod
+BallArithmetic._ciprod_prime
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -65,11 +65,14 @@ parts of `F*G` with downward and upward rounding and returns the result as a
 eigenvalue and singular value enclosures described in Ref.
 [@RumpOishi2001](@cite).
 
+#### Advanced API
+
 Internally we also expose the auxiliary kernels from Ref.
-[@Miyajima2010](@cite).  The helpers `_ccrprod`, `_cr`, `_iprod`, and `_ciprod`
-implement Algorithms 4–7 and propagate rectangular or ball bounds through
-matrix products.  They are available for advanced workflows that need direct
-access to the underlying interval data.
+[@Miyajima2010](@cite).  The helpers `_ccrprod`, `_ccrprod_prime`, `_cr`,
+`_ccr`, `_iprod`, `_iprod_right`, `_ciprod`, and `_ciprod_prime` implement
+Algorithms 4–7, propagating rectangular or ball bounds through matrix products.
+Their docstrings document the respective algorithms and intended use for
+advanced workflows that need direct access to the intermediate interval data.
 
 ```@example oishi
 using BallArithmetic

--- a/src/BallArithmetic.jl
+++ b/src/BallArithmetic.jl
@@ -73,6 +73,8 @@ include("types/vector.jl")
 export BallVector
 include("types/triangularize.jl")
 
+export oishi_MMul
+
 include("types/convertpromote.jl")
 include("norm_bounds/rigorous_norm.jl")
 export upper_bound_norm


### PR DESCRIPTION
## Summary
- remove the exported `proceduresMiyajima2010` container from the public API
- expand the Miyajima 2010 helper docstrings and add an advanced API section to the manual
- update the API reference and tests to reference the individual kernels directly

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test(; test_args=["test_types/test_MMul"])'` *(fails: longstanding Miyajima auxiliary mismatches and distributed certification worker shutdowns)*

------
https://chatgpt.com/codex/tasks/task_e_6909d06e31e483249c397a18e6671bc2