### PR TITLE
Add rigorous GPU GEMM extensions (CUDAExt, CuTileExt)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this package is
+
+BallArithmetic.jl does **rigorous numerical linear algebra** using midpoint–radius (ball) arithmetic. Every operation guarantees the true mathematical result lies inside the returned ball. The core type is `Ball{T, NT}` (radius type `T`, center type `NT`, real or complex); `BallMatrix`/`BallVector` store centers and radii as *separate* dense arrays so the heavy lifting can still go through BLAS. Most algorithms implement papers by Rump, Miyajima, Ogita, Oishi and collaborators (see `references/` and `CITATION.bib`).
+
+## Commands
+
+```bash
+# Run the full test suite (use --project, NOT --project=test; the main project pulls in test deps)
+julia --project -e 'using Pkg; Pkg.test()'
+
+# Run a single test file directly — much faster while iterating
+julia --project test/test_eigenvalues/test_ordschur_ball.jl
+
+# Format code (BlueStyle, see .JuliaFormatter.toml)
+julia -e 'using JuliaFormatter; format(".")'
+
+# Build docs locally
+julia --project=docs docs/make.jl
+```
+
+When adding a test dependency, add it to `test/Project.toml` **and** run
+`julia --project=test -e 'using Pkg; Pkg.resolve()'`. Note `test/` is a full separate environment (`Project.toml` + `Manifest.toml`), not the `[extras]`/`[targets]` mechanism in the root `Project.toml`.
+
+CI (`.github/workflows/CI.yml`) runs on **ubuntu-latest only** (macOS/Windows were dropped due to BLAS floating-point mismatches), on Julia `1` and `nightly`.
+
+## Rigor depends on rounding-mode control (read this before touching arithmetic)
+
+The whole package is only correct because floating-point operations use IEEE directed rounding. Two mechanisms:
+
+- **Float64 BLAS path**: `__init__` in `src/BallArithmetic.jl` swaps in `OpenBLASConsistentFPCSR_jll` (`ConsistentFPCSR=1`) so the rounding mode is consistent across *all* OpenBLAS threads, then runs `NumericalTest.rounding_test`. On non-x86_64 architectures it falls back to single-threaded BLAS. **Do not assume a normal BLAS gives rigorous results.**
+- **Scalar / BigFloat path**: `src/rounding/rounding.jl` defines `add_up`/`add_down`/`mul_up`/… (extending `RoundingEmulator` to BigFloat and Complex) plus the `@up` / `@down` macros, which rewrite an arithmetic expression so every `+ - * /` rounds outward. Use these — never bare arithmetic — when computing a radius or any guaranteed bound. Radii are inflated using `machine_epsilon(T)` and kept strictly positive with `subnormal_min(T)`.
+
+Matrix multiplication has several variants (`MMul3/4/5`, Oishi–Rump complex product) trading precision against speed; see `src/types/matrix.jl` and `test/test_types/test_MMul.jl`.
+
+## Code map
+
+`src/BallArithmetic.jl` is the single include/export manifest — read it first to locate anything. Major directories:
+
+- `types/` — `Ball`, `BallArray`, `BallMatrix`, `BallVector`, conversion/promotion, triangularize
+- `rounding/` — directed-rounding primitives and macros (above)
+- `norm_bounds/` — rigorous L1/L2/L∞ operator-norm bounds, Oishi & Rump–Oishi 2024 σ_min bounds, Collatz iteration
+- `eigenvalues/` — multiple verified eigenvalue algorithms (`miyajima/`, `rump_2022a`, `rump_lange_2023`, `verified_gev`), Schur refinement (`iterative_schur_refinement`, `ordschur_ball`), spectral/Riesz projectors, Newton–Kantorovich eigenpair certification
+- `decompositions/` — verified LU/Cholesky/QR/polar/Takagi, rigorous residual helpers, iterative refinement; `decompositions/svd/` holds rigorous SVD, Miyajima VBD, NJD, adaptive Ogita, precision-cascade SVD
+- `linear_system/` — Krawczyk, HBR, Gaussian elimination, shaving, inflation, Sylvester, preconditioning, overdetermined/least-squares, H-matrix solver
+- `matrix_classifiers/` & `matrix_properties/` — M-matrix test, regularity, determinant enclosures
+- `pseudospectra/` — rigorous resolvent/contour certification; `CertifScripts.jl` (serial + distributed)
+- `numerical_test/` — the startup rounding self-test
+
+`test/` mirrors `src/` directory-for-directory; `test/runtests.jl` is the index of every test file.
+
+### Extensions (`ext/`, weakdeps in `Project.toml`)
+
+Loaded automatically when the trigger package is present: `IntervalArithmeticExt` (Interval↔Ball), `ArbNumericsExt`, `FFTExt` (rigorous FFT), `DistributedExt` (parallel pseudospectrum certification), `DoubleFloatsExt`, `MultiFloatsExt`, `GenericLinearAlgebraExt` (native-BigFloat verified decompositions — the `verified_*_gla` functions are *stubbed* in `src/BallArithmetic.jl` and implemented here), plus experimental `CUDAExt` / `CuTileExt` GPU paths.
+
+`GenericLinearAlgebra` and `GenericSchur` are regular `[deps]`, always loaded — no extension gate needed (used for BigFloat eigen/Schur where LAPACK is Float64-only).
+
+## Conventions and gotchas
+
+- Many high-level routines return a dedicated `*Result` struct (e.g. `RigorousEigenvaluesResult`, `RigorousSVDResult`) rather than a bare tuple — check the struct's fields.
+- Keep helper functions **type-parametric** (`BallMatrix{T,NT}`) so BigFloat inputs work; several bugs have come from Float64-only assumptions.
+- `MultiFloats` is pinned to `2` and support is experimental — don't bump it aggressively.
+- Minimum Julia is `1.10`.

--- a/Project.toml
+++ b/Project.toml
@@ -18,12 +18,17 @@ SetRounding = "3cc68bcd-71a2-5612-b932-767ffbe40ab0"
 
 [weakdeps]
 ArbNumerics = "7e558dbc-694d-5a72-987c-6f4ebed21442"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CUDACore = "bd0ed864-bdfe-4181-a5ed-ce625a5fdea2"
+cuTile = "0dea8319-8c4a-4662-a73d-20234d115b9a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 
 [extensions]
 ArbNumericsExt = "ArbNumerics"
+CUDAExt = "CUDA"
+CuTileExt = ["cuTile", "CUDACore"]
 DistributedExt = "Distributed"
 DoubleFloatsExt = "DoubleFloats"
 FFTExt = "FFTW"
@@ -34,6 +39,9 @@ MultiFloatsExt = "MultiFloats"
 [compat]
 ArbNumerics = "1"
 Combinatorics = "1"
+CUDA = "5, 6"
+CUDACore = "6"
+cuTile = "0.3"
 DoubleFloats = "1"
 FFTW = "1"
 GenericLinearAlgebra = "0.3, 0.4"

--- a/experiments/cutile_probe/Project.toml
+++ b/experiments/cutile_probe/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+BallArithmetic = "77e4f72b-b5a4-4fb0-ac2a-dcc32095a072"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CUDACore = "bd0ed864-bdfe-4181-a5ed-ce625a5fdea2"
+cuTile = "0dea8319-8c4a-4662-a73d-20234d115b9a"

--- a/experiments/cutile_probe/bench_mmul4.jl
+++ b/experiments/cutile_probe/bench_mmul4.jl
@@ -1,0 +1,79 @@
+# Benchmark: rigorous MMul4 (ball-arithmetic GEMM), CPU Float64 vs GPU Float64.
+#
+# Both paths run the SAME algorithm (directed-rounding outer-product
+# accumulation): CPU via SetRounding/OpenBLASConsistentFPCSR, GPU via the
+# CuTileExt kernel (@fpmode outer-product). We time only the matmul, with a
+# warmup to exclude compilation, and verify the GPU result still overlaps the
+# CPU result before reporting timings.
+
+using Random, Printf, LinearAlgebra
+using CUDACore
+using BallArithmetic
+using cuTile  # triggers CuTileExt
+
+const have_ext = Base.get_extension(BallArithmetic, :CuTileExt) !== nothing
+@assert have_ext "CuTileExt failed to load"
+
+# Median wall time (seconds) of `f()` over `nrep` runs after `nwarm` warmups.
+function timeit(f; nwarm=2, nrep=5)
+    for _ in 1:nwarm
+        f()
+    end
+    ts = Float64[]
+    for _ in 1:nrep
+        t0 = time_ns()
+        f()
+        push!(ts, (time_ns() - t0) / 1e9)
+    end
+    return sort(ts)[cld(length(ts), 2)]
+end
+
+function make_ball(::Type{T}, M, K) where {T}
+    rng = MersenneTwister(7)
+    m = rand(rng, T, M, K) .- T(0.5)
+    r = rand(rng, T, M, K) .* T(1e-3)
+    return m, r
+end
+
+function bench(::Type{T}, M, N, K) where {T}
+    mA, rA = make_ball(T, M, K)
+    mB, rB = make_ball(T, K, N)
+
+    A_cpu = BallMatrix(mA, rA)
+    B_cpu = BallMatrix(mB, rB)
+    A_gpu = BallMatrix(CuArray(mA), CuArray(rA))
+    B_gpu = BallMatrix(CuArray(mB), CuArray(rB))
+
+    # Correctness check (overlap) before timing.
+    C_cpu = BallArithmetic.MMul4(A_cpu, B_cpu)
+    C_gpu = BallArithmetic.MMul4(A_gpu, B_gpu)
+    CUDACore.synchronize()
+    mC_c, rC_c = mid(C_cpu), rad(C_cpu)
+    mC_g, rC_g = Array(mid(C_gpu)), Array(rad(C_gpu))
+    overlap = all(max.(mC_g .- rC_g, mC_c .- rC_c) .<=
+                  min.(mC_g .+ rC_g, mC_c .+ rC_c))
+
+    t_cpu = timeit() do
+        BallArithmetic.MMul4(A_cpu, B_cpu)
+    end
+    t_gpu = timeit() do
+        C = BallArithmetic.MMul4(A_gpu, B_gpu)
+        CUDACore.synchronize()
+        C
+    end
+
+    # 2 GEMMs worth of flops in MMul4's dominant cost (mid + radius accum).
+    gflop = 2.0 * 2.0 * M * N * K / 1e9
+    @printf("  %dx%dx%d  CPU %8.2f ms  GPU %8.2f ms  speedup %5.2fx  | CPU %6.1f GF/s  GPU %7.1f GF/s  | overlap=%s\n",
+        M, N, K, t_cpu*1e3, t_gpu*1e3, t_cpu/t_gpu,
+        gflop/t_cpu, gflop/t_gpu, overlap)
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()))
+println("BLAS threads: ", BLAS.get_num_threads())
+println("\nFloat64 rigorous MMul4 — CPU vs GPU")
+println("="^96)
+for (M, N, K) in [(128,128,128), (256,256,256), (512,512,512),
+                  (1024,1024,1024), (2048,2048,2048)]
+    bench(Float64, M, N, K)
+end

--- a/experiments/cutile_probe/gemmul8_bench.jl
+++ b/experiments/cutile_probe/gemmul8_bench.jl
@@ -1,0 +1,19 @@
+using CUDACore, CUDA, Random, Printf, LinearAlgebra
+include("gemmul8_port.jl")
+const BB=7; const BV=2.0^BB
+function sl(Ah,s); D=Vector{CuArray{Int8,2}}(undef,s); t=copy(Ah); for i in 1:s; t.*=BV; di=round.(t); D[i]=Int8.(di); t.-=di; end; D; end
+function schemeI(dA,dB;s=8,T=10)
+    σA=scale_exp(dA;dims=2); σB=scale_exp(dB;dims=1)
+    DA=sl(dA.*(2.0.^(.-σA)),s); DB=sl(dB.*(2.0.^(.-σB)),s)
+    M_,N_=size(dA,1),size(dB,2); S=CUDA.zeros(Float64,M_,N_); Cij=CUDA.zeros(Int32,M_,N_)
+    for i in 1:s, j in 1:s; i+j<=T||continue; fill!(Cij,Int32(0)); gemmI8!('N','N',Int32(1),DA[i],DB[j],Int32(0),Cij); S.+=Float64.(Cij).*(2.0^(-BB*(i+j))); end
+    (S.*(2.0.^σA)).*(2.0.^σB)
+end
+gt(f;nw=2,nr=6)=(for _ in 1:nw;f();CUDACore.synchronize();end;ts=Float64[];for _ in 1:nr;t0=time_ns();f();CUDACore.synchronize();push!(ts,(time_ns()-t0)/1e9);end;sort(ts)[cld(nr,2)])
+function bench(M,N,K)
+    rng=MersenneTwister(1); A=randn(rng,M,K); B=randn(rng,K,N); dA=CuArray(A); dB=CuArray(B)
+    tf=gt(()->dA*dB); tI=gt(()->schemeI(dA,dB;s=8,T=10)); tII=gt(()->gemmul8_dgemm(A,B;num_moduli=14))
+    @printf("  %d^3: FP64 %7.2f | SchemeI(43) %7.2f | GEMMul8-port(14) %7.2f ms  (%.2fx SchemeI, %.2fx FP64)\n", M, tf*1e3, tI*1e3, tII*1e3, tI/tII, tf/tII)
+end
+println("\n== GEMMul8 port benchmark ==")
+for s in [1024,2048,4096]; bench(s,s,s); end

--- a/experiments/cutile_probe/gemmul8_port.jl
+++ b/experiments/cutile_probe/gemmul8_port.jl
@@ -1,0 +1,151 @@
+# gemmul8_port.jl — a Julia port of RIKEN R-CCS's GEMMul8 (Ozaki Scheme II).
+#
+# This is a Julia/CUDA.jl port of the INT8 DGEMM path of GEMMul8:
+#     https://github.com/RIKEN-RCCS/GEMMul8   (MIT License, (c) 2025- RIKEN R-CCS)
+# based on:
+#     Ozaki, Uchino, Imamura, "Ozaki Scheme II", arXiv:2504.08009 (2025).
+#
+# Original GEMMul8 license (MIT) reproduced per its terms:
+#   MIT License. Copyright (c) 2025- RIKEN R-CCS. Permission is hereby granted,
+#   free of charge, ... THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY ...
+#   (full text: /tmp/GEMMul8/LICENSE and the upstream repository).
+#
+# Key fusion ported from GEMMul8 (vs the earlier hand-rolled probe_schemeII_gpu.jl):
+#   * NO Garner mixed-radix. The reconstruction uses the DIRECT CRT formula with
+#     PRECOMPUTED weights qPi = q_i·P_i (P_i=P/p_i, q_i=P_i^{-1} mod p_i), stored
+#     as double-double, accumulated with two FMAs/term (GEMMul8 accumulator_double2),
+#     then the balanced reduction  X = C64f - P·rint(C64f/P)  (rint => signed),
+#     and the diagonal rescale — ALL in ONE fused per-element kernel
+#     (GEMMul8 invscal_device).
+
+using CUDACore, CUDA
+using Random, Printf, LinearAlgebra
+
+const MODULI  = Int[256,255,253,251,247,239,233,229,227,223,217,211,199,197,193]
+const gemmI8! = CUDA.CUBLAS.gemmEx!
+
+scale_exp(A; dims) = (mx = maximum(abs.(A); dims=dims);
+    ifelse.(mx .== 0, 0.0, ceil.(log2.(max.(mx, floatmin(Float64)))) .+ 1.0))
+
+# Fused residue extraction (port of GEMMul8 extract_A_lo / scaling): read each
+# input element ONCE, form the scaled integer A' = round(X·2^(k-σ)), and write
+# all `s` balanced-INT8 residues A' mod p_i.  `lo` is (rows, cols, s); `sft` is
+# the per-row (A) or per-col (B) shift exponent; `rowwise` selects which.
+function fused_residues_kernel!(lo, X, sft, mods, nrows, sz, s, rowwise, k)
+    idx = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if idx <= sz
+        @inbounds begin
+            r = (idx - 1) % nrows + 1
+            c = (idx - 1) ÷ nrows + 1
+            e = rowwise ? sft[r] : sft[c]
+            ap = round(X[idx] * exp2(Float64(k) - e))      # A' = round(X·2^(k-σ))
+            for i in 1:s
+                m  = mods[i]
+                rr = ap - m * floor(ap / m)                # A' mod m  in [0,m)
+                rr = rr < 0 ? rr + m : rr
+                rr = rr >= m ? rr - m : rr
+                rb = (2 * rr >= m) ? rr - m : rr           # balance -> [-m/2, m/2)
+                lo[idx + (i - 1) * sz] = unsafe_trunc(Int8, rb)
+            end
+        end
+    end
+    return nothing
+end
+
+function fused_residues!(lo, X, sft, mods_d, nrows, s, k, rowwise)
+    sz = length(X)
+    threads = 256; blocks = cld(sz, threads)
+    @cuda threads=threads blocks=blocks fused_residues_kernel!(
+        lo, X, sft, mods_d, nrows, sz, s, rowwise, k)
+    return lo
+end
+
+# --- fused inverse-scaling kernel (port of GEMMul8 invscal_device) ---
+# Cmid layout (sizeC, s): residue of modulus i at linear offset idx + (i-1)*sizeC.
+function invscal_kernel!(C, Cmid, qhi, qlo, Px, Py, invP, scaleA, scaleB, M, sizeC, s)
+    idx = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if idx <= sizeC
+        col = (idx - 1) ÷ M + 1
+        row = (idx - 1) % M + 1
+        chi = 0.0; clo = 0.0
+        @inbounds for i in 1:s
+            a = Float64(Cmid[idx + (i-1)*sizeC])
+            chi = fma(qhi[i], a, chi)      # error-free part (GEMMul8 .x)
+            clo = fma(qlo[i], a, clo)      # correction part  (GEMMul8 .y)
+        end
+        quot = round(invP * chi)                       # rint(C64f / P)
+        crt  = fma(Py, quot, fma(Px, quot, chi) + clo) # C64f - P*quot  (P = -prod)
+        @inbounds C[idx] = crt * scaleA[row] * scaleB[col]
+    end
+    return nothing
+end
+
+function gemmul8_dgemm(A, B; num_moduli=14, k=53)
+    M_, N_, K_ = size(A,1), size(B,2), size(A,2)
+    sizeC = M_ * N_; s = num_moduli; mods = MODULI[1:s]
+    dA = CuArray(A); dB = CuArray(B)
+    σA = scale_exp(dA; dims=2); σB = scale_exp(dB; dims=1)
+
+    # fused residue extraction: one pass over A and one over B produce ALL moduli
+    mods_d = CuArray(Int32.(mods))
+    Alo = CuArray{Int8}(undef, M_, K_, s); Blo = CuArray{Int8}(undef, K_, N_, s)
+    fused_residues!(Alo, dA, vec(σA), mods_d, M_, s, k, true)   # per-row shift
+    fused_residues!(Blo, dB, vec(σB), mods_d, K_, s, k, false)  # per-col shift
+
+    # one INT8 GEMM per modulus; reduce mod p_i directly into the Cmid buffer
+    Cmid = CUDA.zeros(Int32, sizeC, s)
+    Cij  = CUDA.zeros(Int32, M_, N_)
+    for (i,m) in enumerate(mods)
+        At = @view Alo[:, :, i]; Bt = @view Blo[:, :, i]
+        fill!(Cij, Int32(0)); gemmI8!('N','N', Int32(1), At, Bt, Int32(0), Cij)
+        @views Cmid[:, i] .= vec(mod.(Cij, Int32(m)))
+    end
+
+    # precompute CRT weights (host) as double-double, GEMMul8-style: the hi part
+    # is qPi truncated to (53 - ceil(log2(rho))) bits so the running accumulation
+    # Σ qhi·a_i is EXACT (error-free); lo captures the remainder.  rho bounds the
+    # accumulated residue magnitude.
+    qhi = zeros(s); qlo = zeros(s)
+    P = prod(BigInt.(mods))
+    rho = sum(div(m, 2) for m in mods)
+    guard = ceil(Int, log2(rho))
+    E = ndigits(P, base = 2) - 1            # floor(log2(P)) = exponent of largest weight
+    L = E - 52 + guard                      # round all weights to multiples of 2^L
+    twoL = BigInt(1) << L
+    for i in 1:s
+        Pi  = P ÷ mods[i]
+        qi  = invmod(mod(Pi, mods[i]), mods[i])
+        qPi = qi * Pi                                  # exact BigInt weight
+        n   = fld(qPi + (twoL >> 1), twoL)             # round to nearest multiple of 2^L
+        qhi[i] = Float64(n) * 2.0^L                    # exact: n < 2^(52-guard)
+        qlo[i] = Float64(qPi - n * twoL)               # remainder
+    end
+    Px = 0.0; Py = 0.0
+    setprecision(BigFloat, 400) do
+        Pneg = -BigFloat(P); Px = Float64(Pneg); Py = Float64(Pneg - Px)
+    end
+    invP = Float64(1 / BigFloat(P))
+
+    out = CUDA.zeros(Float64, M_, N_)
+    scaleA = vec(2.0 .^ (σA .- k)); scaleB = vec(2.0 .^ (σB .- k))
+    dqhi = CuArray(qhi); dqlo = CuArray(qlo)
+    threads = 256; blocks = cld(sizeC, threads)
+    @cuda threads=threads blocks=blocks invscal_kernel!(out, Cmid, dqhi, dqlo,
+        Px, Py, invP, scaleA, scaleB, M_, sizeC, s)
+    return out
+end
+
+function run(M, N, K; s=14)
+    rng = MersenneTwister(1)
+    A = randn(rng, Float64, M, K); B = randn(rng, Float64, K, N)
+    P = setprecision(BigFloat, 300) do; BigFloat.(A) * BigFloat.(B); end
+    relerr(C) = Float64(maximum(abs.(BigFloat.(C) .- P)) / maximum(abs.(P)))
+    C = Array(gemmul8_dgemm(A, B; num_moduli=s)); CUDACore.synchronize()
+    @printf("  %d^3  num_moduli=%d:  relerr = %.3e\n", M, s, relerr(C))
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    println("Device: ", CUDACore.name(CUDACore.device()), "\n")
+    for s in (13, 14, 15); run(256, 256, 256; s=s); end
+    run(512, 512, 512; s=14)
+end

--- a/experiments/cutile_probe/issue_draft.md
+++ b/experiments/cutile_probe/issue_draft.md
@@ -1,0 +1,127 @@
+## `@fpmode rounding_mode` is silently ignored by the tile-level `mma` / `muladd` matmul
+
+### Summary
+
+`ct.@fpmode rounding_mode=ct.Rounding.PosInf` (and `NegInf`) has no effect on the result of tile-level matrix multiplications produced by `muladd(a::Tile, b::Tile, acc::Tile)` (which lowers to the `mma` intrinsic). Running the same matmul under `PosInf`, `NegInf`, and `NearestEven` produces **bitwise-identical** outputs.
+
+The mode *does* take effect when the matmul is rewritten as elementwise tile ops (`mulf` + `addf`), which is consistent with my reading of `arithmetic.jl` (each elementwise intrinsic passes `fpmode_kwargs(ctx)` to its encoder) versus `core.jl` where `encode_MmaFOp!` is called without any rounding/mode attribute.
+
+This matters for rigorous numerics: I'm writing a CUDA backend for [BallArithmetic.jl](https://github.com/orkolorko/BallArithmetic.jl) that needs directed-rounding matrix multiplication (Miyajima/Rump-style verified GEMM); without `@fpmode` reaching the `mma` op, the entire library has to fall back to elementwise accumulation, losing the tensor-core path.
+
+### Environment
+
+- cuTile 0.3.0
+- Julia 1.12.6
+- CUDA driver 580.142 (CUDA Runtime via `CUDA_Runtime_jll`)
+- GPU: NVIDIA GeForce RTX 4060 Ti (Ada, sm_8.9)
+- Linux 6.17.0
+
+### Minimal reproducer
+
+```julia
+using CUDACore
+using cuTile: cuTile
+import cuTile as ct
+using Random, Printf
+
+function gemm_kernel!(A::ct.TileArray{T,2}, B::ct.TileArray{T,2}, C::ct.TileArray{T,2},
+                     tm::Int, tn::Int, tk::Int, rmode) where {T}
+    bid_m = ct.bid(1)
+    bid_n = ct.bid(2)
+    num_k = ct.num_tiles(A, 2, (tm, tk))
+
+    acc = zeros(T, tm, tn)
+
+    # NO TFloat32 conversion — full IEEE precision so the rounding-mode
+    # question is well-posed.
+    ct.@fpmode rounding_mode=rmode flush_to_zero=false begin
+        for k in Int32(1):num_k
+            a = ct.load(A; index=(bid_m, k), shape=(tm, tk), padding_mode=ct.PaddingMode.Zero)
+            b = ct.load(B; index=(k, bid_n), shape=(tk, tn), padding_mode=ct.PaddingMode.Zero)
+            acc = muladd(a, b, acc)
+        end
+    end
+    ct.store(C; index=(bid_m, bid_n), tile=acc)
+    return nothing
+end
+
+function run_one(::Type{T}, M, N, K, tm, tn, tk, rmode) where {T}
+    A = CuArray(rand(MersenneTwister(1), T, M, K))
+    B = CuArray(rand(MersenneTwister(2), T, K, N))
+    C = CuArray{T}(undef, M, N)
+    grid = (cld(M, tm), cld(N, tn))
+    @cuda backend=cuTile blocks=grid gemm_kernel!(A, B, C,
+        ct.Constant(tm), ct.Constant(tn), ct.Constant(tk), ct.Constant(rmode))
+    CUDACore.synchronize()
+    return Array(C)
+end
+
+function probe(::Type{T}; M=128, N=128, K=512, tm=32, tn=32, tk=32) where {T}
+    C_up = run_one(T, M, N, K, tm, tn, tk, ct.Rounding.PosInf)
+    C_dn = run_one(T, M, N, K, tm, tn, tk, ct.Rounding.NegInf)
+    C_ne = run_one(T, M, N, K, tm, tn, tk, ct.Rounding.NearestEven)
+    diff = C_up .- C_dn
+    println(@sprintf("%-10s nonzero gap entries / total: %d / %d   max gap: %g",
+        T, count(>(0), diff), length(C_up), maximum(diff)))
+    println(@sprintf("           Up == Dn (bitwise): %s", C_up == C_dn))
+    println(@sprintf("           Up == NearestEven : %s", C_up == C_ne))
+end
+
+probe(Float32)
+probe(Float64)
+```
+
+Output:
+
+```
+Float32    nonzero gap entries / total: 0 / 16384   max gap: 0
+           Up == Dn (bitwise): true
+           Up == NearestEven : true
+Float64    nonzero gap entries / total: 0 / 16384   max gap: 0
+           Up == Dn (bitwise): true
+           Up == NearestEven : true
+```
+
+### Expected behaviour
+
+With `K=512` random `[0,1)` inputs, each output entry is a sum of 512 products; in `Float32` the gap between `PosInf` and `NegInf` should be on the order of `K · eps(Float32) · mean ≈ 3e-5`. Concretely, when I rewrite the same matmul using only elementwise tile ops (an outer-product accumulation `acc + a_col * b_row` with `(tm × 1) × (1 × tn)` loads inside the same `@fpmode` scope), I get strictly one-sided bracketing on every entry and the expected gap magnitude. So `@fpmode` *is* propagating to `mulf`/`addf` — just not to `mma`.
+
+### Root cause (apparent)
+
+`src/compiler/intrinsics/core.jl:442` — `emit_intrinsic!(ctx, ::typeof(Intrinsics.mma), args)` ends with
+
+```julia
+encode_MmaFOp!(cb, acc.type_id, lhs.v, rhs.v, acc.v)
+```
+
+with no `fpmode_kwargs(ctx)...` (compare with e.g. `emit_intrinsic!` for `addf` at `src/compiler/intrinsics/arithmetic.jl:430` which does forward them). So even if the user sets `rounding_mode`, the attribute never reaches `mmaf`/`mmai`.
+
+I realize this likely reflects the underlying hardware reality: NVIDIA tensor-core MMA instructions are fixed to round-to-nearest-even, and Tile IR may not currently expose a directed-rounding variant. But silently ignoring the mode set by the surrounding `@fpmode` scope is surprising — at minimum it would be helpful to either:
+
+1. Throw an `IRError` at codegen time when an `mma` op is emitted inside a scope whose `rounding_mode` is not `NearestEven`/`Approx`/inherited-default, or
+2. Document explicitly in the `@fpmode` docstring and on `Intrinsics.mma` that the rounding-mode attribute does not reach the matmul intrinsic, and recommend the elementwise rewrite for users who need directed rounding, or
+3. Plumb the attribute through `encode_MmaFOp!` to a future Tile-IR-level directed-rounding mma (when Tile IR / hardware supports it — e.g. some Blackwell modes).
+
+### Workaround I'm using
+
+Express the matmul as outer-product accumulation:
+
+```julia
+ct.@fpmode rounding_mode=ct.Rounding.PosInf flush_to_zero=false begin
+    for k in Int32(1):Int32(K)
+        a_col = ct.load(A; index=(bid_m, k), shape=(tm, 1), padding_mode=ct.PaddingMode.Zero)
+        b_row = ct.load(B; index=(k, bid_n), shape=(1, tn), padding_mode=ct.PaddingMode.Zero)
+        acc = acc + a_col * b_row
+    end
+end
+```
+
+This works (verified rigorously bracketing the CPU `setrounding` result), but bypasses tensor cores and costs ~5× throughput on Float32 (no penalty on Float64 since consumer Ada has no Float64 tensor cores anyway).
+
+### Asks (in priority order)
+
+1. **At minimum:** documentation on `@fpmode`, `muladd(::Tile,::Tile,::Tile)`, and `Intrinsics.mma` noting that the rounding mode is not honored by tile matmul, so users know they need the elementwise rewrite.
+2. **Better:** an `IRError` (or compile-time warning) when `mma` is emitted under a non-default `rounding_mode` scope, so the silent miss can't happen.
+3. **Best, longer-term:** wire `fpmode_kwargs` through to `encode_MmaFOp!` so that when/if Tile IR exposes a directed-rounding mma (Blackwell-class hardware, software fallback, etc.), it Just Works.
+
+Happy to send a PR for (1) or (2) if there's interest.

--- a/experiments/cutile_probe/probe.jl
+++ b/experiments/cutile_probe/probe.jl
@@ -1,0 +1,78 @@
+# Probe: does cuTile's @fpmode actually round every FMA in a tile-level matmul?
+#
+# Strategy: pick A, B with many addends so accumulated rounding error is
+# visible, then compute C = A*B under @fpmode rounding_mode=PosInf and
+# rounding_mode=NegInf using a Float32 (and Float64) tile accumulator.
+#
+# Pass criteria:
+#   1. C_up[i,j] >= C_dn[i,j] for every entry (one-sidedness)
+#   2. C_up[i,j] >  C_dn[i,j] for many entries (mode is not a no-op)
+#   3. CPU midpoint (RoundNearest) lies in [C_dn, C_up] for every entry
+#
+# If any of these fails, @fpmode is not rigorous enough to back MMul4.
+
+using CUDACore
+using cuTile: cuTile
+import cuTile as ct
+using Random, Printf, LinearAlgebra
+
+function gemm_kernel!(A::ct.TileArray{T,2}, B::ct.TileArray{T,2}, C::ct.TileArray{T,2},
+                     tm::Int, tn::Int, tk::Int, rmode) where {T}
+    bid_m = ct.bid(1)
+    bid_n = ct.bid(2)
+    num_k = ct.num_tiles(A, 2, (tm, tk))
+
+    acc = zeros(T, tm, tn)
+
+    # Note: NO TFloat32 conversion. Keep full IEEE precision so the
+    # rounding mode is a meaningful question.
+    ct.@fpmode rounding_mode=rmode flush_to_zero=false begin
+        for k in Int32(1):num_k
+            a = ct.load(A; index=(bid_m, k), shape=(tm, tk), padding_mode=ct.PaddingMode.Zero)
+            b = ct.load(B; index=(k, bid_n), shape=(tk, tn), padding_mode=ct.PaddingMode.Zero)
+            acc = muladd(a, b, acc)
+        end
+    end
+    ct.store(C; index=(bid_m, bid_n), tile=acc)
+    return nothing
+end
+
+function run_one(::Type{T}, M, N, K, tm, tn, tk, rmode) where {T}
+    A = CuArray(rand(MersenneTwister(1), T, M, K))
+    B = CuArray(rand(MersenneTwister(2), T, K, N))
+    C = CuArray{T}(undef, M, N)
+    grid = (cld(M, tm), cld(N, tn))
+    @cuda backend=cuTile blocks=grid gemm_kernel!(A, B, C,
+        ct.Constant(tm), ct.Constant(tn), ct.Constant(tk), ct.Constant(rmode))
+    CUDACore.synchronize()
+    return Array(A), Array(B), Array(C)
+end
+
+function probe(::Type{T}; M=128, N=128, K=512, tm=32, tn=32, tk=32) where {T}
+    println("--- $(T): $(M)x$(K) * $(K)x$(N), tiles $(tm)x$(tn)x$(tk) ---")
+    A, B, C_up = run_one(T, M, N, K, tm, tn, tk, ct.Rounding.PosInf)
+    _, _, C_dn = run_one(T, M, N, K, tm, tn, tk, ct.Rounding.NegInf)
+    _, _, C_ne = run_one(T, M, N, K, tm, tn, tk, ct.Rounding.NearestEven)
+
+    diff = C_up .- C_dn
+    one_sided = all(>=(0), diff)
+    nz = count(>(0), diff)
+    max_gap = maximum(diff)
+    cpu_ref = A * B  # CPU reference, ordinary rounding
+
+    bracket_ok = all(C_dn .<= cpu_ref .<= C_up)
+    ne_in_bracket = all(C_dn .<= C_ne .<= C_up)
+
+    println(@sprintf("  one-sided   (C_up >= C_dn always)        : %s", one_sided))
+    println(@sprintf("  nonzero gap entries / total              : %d / %d", nz, length(C_up)))
+    println(@sprintf("  max gap                                  : %g", max_gap))
+    println(@sprintf("  CPU ref in [C_dn, C_up]                  : %s", bracket_ok))
+    println(@sprintf("  NearestEven in [C_dn, C_up]              : %s", ne_in_bracket))
+    println()
+    return (one_sided=one_sided, nz=nz, max_gap=max_gap, bracket=bracket_ok)
+end
+
+println("CUDA device: ", CUDACore.name(CUDACore.device()))
+println()
+probe(Float32)
+probe(Float64)

--- a/experiments/cutile_probe/probe_adjoint_dispatch.jl
+++ b/experiments/cutile_probe/probe_adjoint_dispatch.jl
@@ -1,0 +1,39 @@
+# Verify the GPU MMul4 now fires for adjoint/transpose operands (U'·U etc.) and
+# stays rigorous, rather than silently falling back to the (non-rigorous on GPU)
+# generic CPU MMul4.
+using BallArithmetic, CUDA, LinearAlgebra, Random, Printf
+using BallArithmetic: mid, rad
+
+# Is this BallMatrix product handled by CUDAExt's GPU MMul4?  We detect it via the
+# method that `MMul4` resolves to: CUDAExt vs the generic src method.
+gpu_method(A, B) = (m = which(BallArithmetic.MMul4, (typeof(A), typeof(B)));
+    string(parentmodule(m)) == "CUDAExt")
+
+function check(label, A, B)
+    routed = gpu_method(A, B)
+    C = A * B                                  # dispatches through MMul4
+    onGPU = mid(C) isa CUDA.CuArray
+    # rigor: ball must contain the BigFloat-exact midpoint product
+    setprecision(BigFloat, 256) do
+        trueC = (BigFloat.(Array(mid(A))) .+ 0) * (BigFloat.(Array(mid(B))))
+        # account only for midpoint here (operands have small radii handled by MMul4)
+        lo = BigFloat.(Array(mid(C))) .- BigFloat.(Array(rad(C)))
+        hi = BigFloat.(Array(mid(C))) .+ BigFloat.(Array(rad(C)))
+        contains = all(lo .<= trueC .<= hi)
+        @printf("%-16s routed→CUDAExt=%-5s  resultOnGPU=%-5s  enclosesTrue=%-5s\n",
+            label, routed, onGPU, contains)
+    end
+end
+
+n = 256
+rng = MersenneTwister(1)
+M = randn(rng, n, n) ./ sqrt(n)
+U = BallMatrix(CuArray(M), CUDA.fill(1e-14, n, n))
+V = BallMatrix(CuArray(randn(rng, n, n) ./ sqrt(n)), CUDA.fill(1e-14, n, n))
+
+println("Device: ", CUDA.name(CUDA.device()), "\n")
+check("U * V",     U, V)            # plain × plain (baseline, already worked)
+check("U' * V",    U', V)           # adjoint × plain
+check("U * V'",    U, V')           # plain × adjoint
+check("U' * U",    U', U)           # the SVD orthogonality-defect product
+check("transpose", transpose(U), V) # transpose × plain

--- a/experiments/cutile_probe/probe_collatz_gpu.jl
+++ b/experiments/cutile_probe/probe_collatz_gpu.jl
@@ -1,0 +1,66 @@
+# Rigorous Collatz ‖A‖₂ upper bound on the GPU.
+#
+# collatz bound = sqrt(ρ(|A|ᵀ|A|)), via Collatz–Wielandt: for B = |A|ᵀ|A| ≥ 0 and
+# any x > 0,  ρ(B) ≤ maxᵢ (Bx)ᵢ/xᵢ.  We iterate x ← Bx a few times to get a good x,
+# then bound the final ratio.  Rigor without directed rounding: B,x ≥ 0, so a
+# round-to-nearest cuBLAS GEMV inflated by (1+(n+2)u) is a valid UPPER bound on Bx,
+# and the denominator xᵢ is the exact positive vector we chose -> ratio rounds up.
+
+using BallArithmetic, CUDA, LinearAlgebra, Random, Printf
+using BallArithmetic: mid, rad, collatz_upper_bound_L2_opnorm
+
+const u = eps(Float64)
+
+# entrywise upper bound on |A| over the ball: |mid|+rad, inflated to cover RN rounding
+function absupper(A::BallMatrix)
+    M = abs.(mid(A)) .+ rad(A)
+    return M .* (1 + 2u)
+end
+
+# rigorous GPU Collatz upper bound on ‖A‖₂; absU is a dense nonneg CuArray ≥ |A|
+function collatz_gpu(absU::CuArray{Float64}; iterates=5)
+    m, k = size(absU)
+    infl(n) = 1 + (n + 2) * u                 # per-GEMV upper-bound inflation
+    x = CUDA.ones(Float64, k)
+    local xprev
+    for _ in 1:iterates
+        xprev = x
+        y = (absU * x) .* infl(k)             # ≥ |A| x        (RN GEMV + inflate)
+        x = (absU' * y) .* infl(m)            # ≥ |A|ᵀ|A| x
+    end
+    # one more matvec as a rigorous upper bound on B*xprev
+    y  = (absU * xprev) .* infl(k)
+    Bx = (absU' * y)    .* infl(m)            # ≥ B*xprev (elementwise)
+    ratio = Array(Bx ./ xprev)               # xprev exact & >0
+    lam = maximum(ratio) * (1 + 2u)
+    return sqrt(lam) * (1 + u)
+end
+
+gt(f; nr=4) = (f(); CUDA.synchronize(); minimum((CUDA.@elapsed f()) for _ in 1:nr))
+ct(f; nr=4) = (f(); minimum(@elapsed(f()) for _ in 1:nr))
+
+function run(n; seed=1)
+    rng = MersenneTwister(seed)
+    A = BallMatrix(randn(rng, n, n) ./ sqrt(n), fill(1e-13, n, n))
+
+    cpu_bound = collatz_upper_bound_L2_opnorm(A)
+    absU_d = CuArray(absupper(A))
+    gpu_bound = collatz_gpu(absU_d)
+
+    # rigor reference: true ‖A‖₂ (largest singular value of a sampled matrix in ball)
+    truenorm = 0.0
+    for _ in 1:50
+        S = mid(A) .+ (2 .* rand(rng, n, n) .- 1) .* rad(A)
+        truenorm = max(truenorm, opnorm(S, 2))
+    end
+
+    tg = gt(() -> collatz_gpu(absU_d))
+    tc = ct(() -> collatz_upper_bound_L2_opnorm(A))
+    @printf("n=%-4d | CPU collatz=%.6f (%.4fs) | GPU collatz=%.6f (%.4fs) | true≈%.6f | both≥true=%s | speedup %.1fx\n",
+        n, cpu_bound, tc, gpu_bound, tg, truenorm,
+        (cpu_bound ≥ truenorm && gpu_bound ≥ truenorm), tc/tg)
+    flush(stdout)
+end
+
+println("Device: ", CUDA.name(CUDA.device()), "\n")
+for n in (512, 1024, 2048, 4096); run(n); end

--- a/experiments/cutile_probe/probe_elementwise.jl
+++ b/experiments/cutile_probe/probe_elementwise.jl
@@ -1,0 +1,66 @@
+# Probe v2: bypass the `mma` tile-matmul intrinsic (whose codegen ignores
+# `@fpmode`) and compute matmul as accumulated elementwise tile mulf/addf.
+# Those *do* forward the fpmode kwargs to the op (see arithmetic.jl), so
+# this path should be rigorously rounded.
+
+using CUDACore
+using cuTile: cuTile
+import cuTile as ct
+using Random, Printf
+
+# Compute one (tm × tn) output tile by accumulating outer products
+#   acc += A[:, k] * B[k, :]^T
+# using elementwise mulf/addf inside @fpmode. No tile-level muladd.
+function gemm_elem_kernel!(A::ct.TileArray{T,2}, B::ct.TileArray{T,2}, C::ct.TileArray{T,2},
+                           tm::Int, tn::Int, K::Int, rmode) where {T}
+    bid_m = ct.bid(1)
+    bid_n = ct.bid(2)
+
+    acc = zeros(T, tm, tn)
+
+    ct.@fpmode rounding_mode=rmode flush_to_zero=false begin
+        for k in Int32(1):Int32(K)
+            a_col = ct.load(A; index=(bid_m, k), shape=(tm, 1), padding_mode=ct.PaddingMode.Zero)
+            b_row = ct.load(B; index=(k, bid_n), shape=(1, tn), padding_mode=ct.PaddingMode.Zero)
+            acc = acc + a_col * b_row        # broadcast outer product via elementwise mulf+addf
+        end
+    end
+    ct.store(C; index=(bid_m, bid_n), tile=acc)
+    return nothing
+end
+
+function run_one(::Type{T}, M, N, K, tm, tn, rmode) where {T}
+    A = CuArray(rand(MersenneTwister(1), T, M, K))
+    B = CuArray(rand(MersenneTwister(2), T, K, N))
+    C = CuArray{T}(undef, M, N)
+    grid = (cld(M, tm), cld(N, tn))
+    @cuda backend=cuTile blocks=grid gemm_elem_kernel!(A, B, C,
+        ct.Constant(tm), ct.Constant(tn), ct.Constant(K), ct.Constant(rmode))
+    CUDACore.synchronize()
+    return Array(A), Array(B), Array(C)
+end
+
+function probe(::Type{T}; M=64, N=64, K=512, tm=16, tn=16) where {T}
+    println("--- $(T): $(M)x$(K) * $(K)x$(N), tile $(tm)x$(tn), elementwise ---")
+    A, B, C_up = run_one(T, M, N, K, tm, tn, ct.Rounding.PosInf)
+    _, _, C_dn = run_one(T, M, N, K, tm, tn, ct.Rounding.NegInf)
+    _, _, C_ne = run_one(T, M, N, K, tm, tn, ct.Rounding.NearestEven)
+
+    diff = C_up .- C_dn
+    one_sided = all(>=(0), diff)
+    nz = count(>(0), diff)
+    max_gap = maximum(diff)
+
+    ne_in_bracket = all(C_dn .<= C_ne .<= C_up)
+
+    println(@sprintf("  one-sided   (C_up >= C_dn always)        : %s", one_sided))
+    println(@sprintf("  nonzero gap entries / total              : %d / %d", nz, length(C_up)))
+    println(@sprintf("  max gap                                  : %g", max_gap))
+    println(@sprintf("  NearestEven in [C_dn, C_up]              : %s", ne_in_bracket))
+    println()
+end
+
+println("CUDA device: ", CUDACore.name(CUDACore.device()))
+println()
+probe(Float32)
+probe(Float64)

--- a/experiments/cutile_probe/probe_gemmul8_mmul4.jl
+++ b/experiments/cutile_probe/probe_gemmul8_mmul4.jl
@@ -1,0 +1,85 @@
+# Full BallMatrix MMul4 built on the GEMMul8 port (gemmul8_dgemm midpoint).
+# Answers: once we add the radius, is the GPU MMul4 still a big win vs CPU MMul4?
+#
+#   m      = gemmul8_dgemm(mA, mB)               exact-CRT FP64 midpoint
+#   ρ_trunc = |δA|·|mB| + |mA|·|δB| (+ tiny)      input-scaling truncation; since
+#             |δA| <= 2^(σA-k-1) is per-ROW constant, this is row/col sums × bcast
+#             (NO GEMM). Plus u·|m| for the final FP64 rounding.
+#   rC_in  = |mA|·rB + rA·(|mB|+rB)               input-radius prop. (FP32, only if
+#                                                 radii != 0; 2 GEMMs)
+#   C = ( m , ρ_trunc + rC_in ) rounded up
+
+using CUDACore, CUDA, Random, Printf, LinearAlgebra
+using BallArithmetic
+include("gemmul8_port.jl")
+
+const U64 = eps(Float64); const U32 = Float64(eps(Float32))
+
+function gemmul8_mmul4(mA, rA, mB, rB; num_moduli=14, k=53)
+    M_, N_, K_ = size(mA,1), size(mB,2), size(mA,2)
+    m = gemmul8_dgemm(mA, mB; num_moduli=num_moduli, k=k)      # midpoint (port)
+    dmA = CuArray(mA); dmB = CuArray(mB)
+    σA = scale_exp(dmA; dims=2); σB = scale_exp(dmB; dims=1)
+
+    # --- midpoint truncation bound (no GEMM) ---
+    absA = abs.(dmA); absB = abs.(dmB)
+    rowsumA = sum(absA; dims=2) .* (1 + K_*U64)     # M×1, rigorous upper bound
+    colsumB = sum(absB; dims=1) .* (1 + K_*U64)     # 1×N
+    δA = 2.0 .^ (σA .- k .- 1)                      # M×1  (>= |δA| per row)
+    δB = 2.0 .^ (σB .- k .- 1)                      # 1×N
+    ρ_trunc = (δA .* colsumB) .+ (rowsumA .* δB) .+ (Float64(K_) .* (δA .* δB))
+
+    # --- input-radius term (FP32 GEMMs, skipped if radii are zero) ---
+    if any(rA .!= 0) || any(rB .!= 0)
+        drA = CuArray(Float32.(rA)); drB = CuArray(Float32.(rB))
+        amA = abs.(Float32.(dmA)); amB = abs.(Float32.(dmB))
+        t1 = amA * drB; t2 = drA * (amB .+ drB)
+        rC_in = Float64.(t1 .+ t2) .* (1 + (2K_+8)*U32)
+    else
+        rC_in = CUDA.zeros(Float64, M_, N_)
+    end
+
+    rC = (ρ_trunc .+ rC_in .+ (U64 .* abs.(m))) .* (1 + 8U64)
+    CUDACore.synchronize()
+    return Array(m), Array(rC)
+end
+
+gt(f;nw=2,nr=5)=(for _ in 1:nw;f();CUDACore.synchronize();end;ts=Float64[];for _ in 1:nr;t0=time_ns();f();CUDACore.synchronize();push!(ts,(time_ns()-t0)/1e9);end;sort(ts)[cld(nr,2)])
+ct(f;nw=1,nr=3)=(for _ in 1:nw;f();end;ts=Float64[];for _ in 1:nr;t0=time_ns();f();push!(ts,(time_ns()-t0)/1e9);end;sort(ts)[cld(nr,2)])
+
+# correctness: contain the exact ball product
+function verify(M,N,K; radlevel=1e-10, seed=1)
+    rng=MersenneTwister(seed)
+    mA=randn(rng,M,K); rA=abs.(randn(rng,M,K)).*radlevel
+    mB=randn(rng,K,N); rB=abs.(randn(rng,K,N)).*radlevel
+    mC,rC = gemmul8_mmul4(mA,rA,mB,rB)
+    setprecision(BigFloat,300) do
+        ctr=BigFloat.(mA)*BigFloat.(mB)
+        hw =abs.(BigFloat.(mA))*BigFloat.(rB) .+ BigFloat.(rA)*abs.(BigFloat.(mB)) .+ BigFloat.(rA)*BigFloat.(rB)
+        lo_t=ctr.-hw; hi_t=ctr.+hw
+        lo_g=BigFloat.(mC).-BigFloat.(rC); hi_g=BigFloat.(mC).+BigFloat.(rC)
+        ins=all((lo_g.<=lo_t).&(hi_g.>=hi_t))
+        @printf("  %d^3 rad~%.0e: CONTAINS exact ball=%s  radius_rel=%.2e\n",
+            M, radlevel, ins ? "YES" : "NO", Float64(maximum(BigFloat.(rC))/maximum(abs.(ctr))))
+    end
+end
+
+function bench(M,N,K)
+    rng=MersenneTwister(1)
+    mA=randn(rng,M,K); mB=randn(rng,K,N)
+    Ab=BallMatrix(mA); Bb=BallMatrix(mB)              # zero-radius balls
+    rZ=zeros(M,K); rZ2=zeros(K,N)
+    t_cpu = ct(()->BallArithmetic.MMul4(Ab,Bb))
+    t_gpu = gt(()->gemmul8_mmul4(mA,rZ,mB,rZ2))
+    # nonzero-radius GPU cost
+    rA=abs.(randn(rng,M,K)).*1e-10; rB=abs.(randn(rng,K,N)).*1e-10
+    t_gpu_r = gt(()->gemmul8_mmul4(mA,rA,mB,rB))
+    @printf("  %d^3:  CPU MMul4 %8.2f ms | GPU MMul4 (port) zero-rad %7.2f ms (%.1fx) | nonzero-rad %7.2f ms (%.1fx)\n",
+        M, t_cpu*1e3, t_gpu*1e3, t_cpu/t_gpu, t_gpu_r*1e3, t_cpu/t_gpu_r)
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()))
+println("\n== full MMul4 enclosure check ==")
+for rl in (0.0, 1e-10, 1e-5); verify(256,256,256; radlevel=rl); end
+println("\n== full MMul4: GPU (port) vs CPU ==")
+for s in (1024,2048,4096); bench(s,s,s); end

--- a/experiments/cutile_probe/probe_int8_bench.jl
+++ b/experiments/cutile_probe/probe_int8_bench.jl
@@ -1,0 +1,74 @@
+# Benchmark: INT8-Ozaki FP64-emulation vs native FP64 on the GPU, and vs CPU.
+# Question (from arXiv:2504.08009): does exact-INT8-tensor-core emulation beat
+# native FP64 on consumer Ada, as the paper reports ~6-7x on the RTX 4090?
+
+using CUDACore, CUDA
+using Random, Printf, LinearAlgebra
+
+const gemmI8! = CUDA.CUBLAS.gemmEx!
+const B_BITS  = 7
+const BASE    = 2.0^B_BITS
+
+function scale_exp(A; dims)
+    mx = maximum(abs.(A); dims=dims)
+    σ  = ceil.(log2.(max.(mx, floatmin(Float64)))) .+ 1.0
+    return ifelse.(mx .== 0, 0.0, σ)
+end
+function slices(Ahat, s)
+    D = Vector{CuArray{Int8,2}}(undef, s)
+    t = copy(Ahat)
+    for i in 1:s
+        t .*= BASE; di = round.(t); D[i] = Int8.(di); t .-= di
+    end
+    return D
+end
+function int8_ozaki(dA, dB; s=8, T=2s)
+    σA = scale_exp(dA; dims=2); σB = scale_exp(dB; dims=1)
+    DA = slices(dA .* (2.0 .^ (.-σA)), s)
+    DB = slices(dB .* (2.0 .^ (.-σB)), s)
+    M, N = size(dA, 1), size(dB, 2)
+    S = CUDA.zeros(Float64, M, N); Cij = CUDA.zeros(Int32, M, N)
+    for i in 1:s, j in 1:s
+        i + j <= T || continue
+        fill!(Cij, Int32(0))
+        gemmI8!('N','N', Int32(1), DA[i], DB[j], Int32(0), Cij)
+        S .+= Float64.(Cij) .* (2.0^(-B_BITS*(i+j)))
+    end
+    return (S .* (2.0 .^ σA)) .* (2.0 .^ σB)
+end
+
+function timeit(f; nwarm=3, nrep=8)
+    for _ in 1:nwarm; f(); CUDACore.synchronize(); end
+    ts = Float64[]
+    for _ in 1:nrep
+        t0 = time_ns(); f(); CUDACore.synchronize(); push!(ts, (time_ns()-t0)/1e9)
+    end
+    return sort(ts)[cld(length(ts),2)]
+end
+
+function run(M, N, K; seed=1)
+    rng = MersenneTwister(seed)
+    A = randn(rng, Float64, M, K); B = randn(rng, Float64, K, N)
+    dA = CuArray(A); dB = CuArray(B)
+    dAi = CuArray(rand(rng, Int8.(-64:64), M, K)); dBi = CuArray(rand(rng, Int8.(-64:64), K, N))
+    dCi = CUDA.zeros(Int32, M, N)
+    gf = 2.0 * M * N * K / 1e9
+
+    t_fp64 = timeit(() -> dA * dB)
+    t_i8   = timeit(() -> gemmI8!('N','N', Int32(1), dAi, dBi, Int32(0), dCi))
+    t_oz28 = timeit(() -> int8_ozaki(dA, dB; s=8, T=8))
+    t_oz43 = timeit(() -> int8_ozaki(dA, dB; s=8, T=10))
+
+    @printf("  M=%d N=%d K=%d\n", M, N, K)
+    @printf("    native FP64 gemm        %8.3f ms  (%6.1f GF/s)\n", t_fp64*1e3, gf/t_fp64)
+    @printf("    single INT8 gemm        %8.3f ms  (%6.1f GF/s)  -> INT8 is %.1fx FP64/gemm\n",
+            t_i8*1e3, gf/t_i8, t_fp64/t_i8)
+    @printf("    INT8-Ozaki s8 T8  (28)  %8.3f ms  -> %.2fx native FP64\n", t_oz28*1e3, t_fp64/t_oz28)
+    @printf("    INT8-Ozaki s8 T10 (43)  %8.3f ms  -> %.2fx native FP64\n", t_oz43*1e3, t_fp64/t_oz43)
+    println()
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()), "\n")
+for (M,N,K) in [(512,512,512), (1024,1024,1024), (2048,2048,2048), (4096,4096,4096)]
+    run(M, N, K)
+end

--- a/experiments/cutile_probe/probe_int8_mmul4.jl
+++ b/experiments/cutile_probe/probe_int8_mmul4.jl
@@ -1,0 +1,108 @@
+# Probe: a full GPU MMul4 (BallMatrix × BallMatrix → BallMatrix) built on
+# INT8-Ozaki for the midpoint and a LOW-PRECISION (FP32) radius term.
+#
+#   m     = INT8-Ozaki(mA, mB)               exact FP64 midpoint product
+#   ρ     = rigorous bound on |m − mA·mB|     (Ozaki truncation + recomb error)
+#   rC_in = upper_bound(|mA|·rB + rA·(|mB|+rB))  ← FP32 GEMMs, inflated up
+#   C     = ( m ,  ρ + rC_in )                 rounded up
+#
+# Validation: the result must contain the EXACT ball product per entry, whose
+# true center is Σ_k mA·mB and true half-width is Σ_k (|mA|rB + rA|mB| + rA rB).
+# We check containment of that interval (computed in BigFloat).
+
+using CUDACore, CUDA
+using Random, Printf, LinearAlgebra
+
+const gemmI8! = CUDA.CUBLAS.gemmEx!
+const B_BITS = 7; const BASE = 2.0^B_BITS
+const U64 = eps(Float64); const U32 = eps(Float32)
+
+scale_exp(A; dims) = (mx = maximum(abs.(A); dims=dims);
+    ifelse.(mx .== 0, 0.0, ceil.(log2.(max.(mx, floatmin(Float64)))) .+ 1.0))
+function slices(Ahat, s)
+    D = Vector{CuArray{Int8,2}}(undef, s); t = copy(Ahat)
+    for i in 1:s; t .*= BASE; di = round.(t); D[i] = Int8.(di); t .-= di; end
+    return D
+end
+
+# Midpoint product (center m) + rigorous bound ρ on |m − mA·mB|.  (Scheme I.)
+function ozaki_midpoint(dmA, dmB; s=8, T=10)
+    M_, N_, K_ = size(dmA,1), size(dmB,2), size(dmA,2)
+    σA = scale_exp(dmA; dims=2); σB = scale_exp(dmB; dims=1)
+    DA = slices(dmA .* (2.0 .^ (.-σA)), s); DB = slices(dmB .* (2.0 .^ (.-σB)), s)
+    S = CUDA.zeros(Float64, M_, N_); Cij = CUDA.zeros(Int32, M_, N_); ng = 0
+    for i in 1:s, j in 1:s
+        i+j <= T || continue
+        fill!(Cij, Int32(0)); gemmI8!('N','N', Int32(1), DA[i], DB[j], Int32(0), Cij)
+        S .+= Float64.(Cij) .* (2.0^(-B_BITS*(i+j))); ng += 1
+    end
+    scaleA = 2.0 .^ σA; scaleB = 2.0 .^ σB
+    m = (S .* scaleA) .* scaleB
+
+    # ρ: dropped slice-pairs (i+j>T) + recombination rounding (see probe_int8_rigor)
+    mm = fld(T,2); resid = 2.0^(-B_BITS*s - 1)
+    fullA = CUDA.zeros(Float64,M_,K_); loA = CUDA.zeros(Float64,M_,K_)
+    fullB = CUDA.zeros(Float64,K_,N_); loB = CUDA.zeros(Float64,K_,N_)
+    for i in 1:s
+        w = 2.0^(-B_BITS*i)
+        fullA .+= w.*abs.(Float64.(DA[i])); fullB .+= w.*abs.(Float64.(DB[i]))
+        if i > mm; loA .+= w.*abs.(Float64.(DA[i])); loB .+= w.*abs.(Float64.(DB[i])); end
+    end
+    fullA .+= resid; fullB .+= resid; loA .+= resid; loB .+= resid
+    infl = 1.0 + (K_+2)*U64
+    bnd = (loA*fullB).*infl; bnd .+= (fullA*loB).*infl
+    ρ = (((bnd .* scaleA) .* scaleB) .* infl) .+ Float64(ng+3)*U64 .* abs.(m)
+    return m, ρ
+end
+
+# Low-precision (FP32) rigorous upper bound on |mA|·rB + rA·(|mB|+rB).
+function radius_term_fp32(dmA, drA, dmB, drB)
+    K_ = size(dmA, 2)
+    amA = abs.(Float32.(dmA)); amB = abs.(Float32.(dmB))
+    rA32 = Float32.(drA); rB32 = Float32.(drB)
+    t1 = amA * rB32                    # |mA|·rB    (FP32 gemm, round-to-nearest)
+    t2 = rA32 * (amB .+ rB32)          # rA·(|mB|+rB)
+    raw = Float64.(t1 .+ t2)
+    # inflate to a rigorous upper bound: FP32 accumulation (K·u32), the (|mB|+rB)
+    # add, and the Float32 down-conversion of |mA|,|mB| (relative u32 each).
+    infl = 1.0 + Float64(2K_ + 8) * Float64(U32)
+    return raw .* infl
+end
+
+function gpu_mmul4(mA, rA, mB, rB; s=8, T=10)
+    dmA=CuArray(mA); drA=CuArray(rA); dmB=CuArray(mB); drB=CuArray(rB)
+    m, ρ = ozaki_midpoint(dmA, dmB; s=s, T=T)
+    rC_in = radius_term_fp32(dmA, drA, dmB, drB)
+    rC = (ρ .+ rC_in) .* (1.0 + 8U64)          # round up
+    CUDACore.synchronize()
+    return Array(m), Array(rC)
+end
+
+function run(M, N, K; radlevel=1e-10, s=8, T=10, seed=1)
+    rng = MersenneTwister(seed)
+    mA = randn(rng, Float64, M, K); rA = abs.(randn(rng, M, K)) .* radlevel
+    mB = randn(rng, Float64, K, N); rB = abs.(randn(rng, K, N)) .* radlevel
+
+    mC, rC = gpu_mmul4(mA, rA, mB, rB; s=s, T=T)
+
+    # Exact ball product per entry, in BigFloat.
+    inside, minmargin, maxrad_rel = setprecision(BigFloat, 300) do
+        bmA=BigFloat.(mA); brA=BigFloat.(rA); bmB=BigFloat.(mB); brB=BigFloat.(rB)
+        ctr = bmA * bmB
+        hw  = abs.(bmA) * brB .+ brA * abs.(bmB) .+ brA * brB
+        lo_t = ctr .- hw; hi_t = ctr .+ hw
+        lo_g = BigFloat.(mC) .- BigFloat.(rC); hi_g = BigFloat.(mC) .+ BigFloat.(rC)
+        ins = all((lo_g .<= lo_t) .& (hi_g .>= hi_t))
+        mg  = Float64(minimum(min.(lo_t .- lo_g, hi_g .- hi_t)))   # >=0 if contained
+        mr  = Float64(maximum(BigFloat.(rC)) / maximum(abs.(ctr)))
+        (ins, mg, mr)
+    end
+    @printf("  %d^3  rad~%.0e  s=%d T=%d:  CONTAINS exact ball = %s   min margin = %.2e   radius(rel)=%.2e\n",
+            M, radlevel, s, T, inside ? "YES" : "NO", minmargin, maxrad_rel)
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()), "\n")
+for rl in (0.0, 1e-12, 1e-8, 1e-4)
+    run(256, 256, 256; radlevel=rl)
+end
+run(512, 512, 512; radlevel=1e-10)

--- a/experiments/cutile_probe/probe_int8_ozaki.jl
+++ b/experiments/cutile_probe/probe_int8_ozaki.jl
@@ -1,0 +1,88 @@
+# Probe: INT8-Ozaki GEMM (slice-based, the Scheme-I precursor to arXiv:2504.08009).
+#
+# INT8 x INT8 -> INT32 tensor-core products are EXACT. We split each FP64
+# matrix into base-2^7 integer "slices", do exact INT8 GEMMs, and recombine.
+#
+#   A[r,k] = 2^σA[r] * ahat[r,k],   ahat = Σ_i Di_A[i] 2^(-7 i)   (Di_A INT8)
+#   B[k,c] = 2^σB[c] * bhat[k,c],   bhat = Σ_j Dj_B[j] 2^(-7 j)
+#   C = Diag(2^σA) * [ Σ_{i,j} 2^(-7(i+j)) (Di_A[i] · Dj_B[j]) ] * Diag(2^σB)
+#
+# Each (Di_A[i] · Dj_B[j]) is an exact INT8 tensor-core GEMM. Truncating to
+# i+j <= T drops only terms of size <= 2^(-7T) -> a-priori bound (rigor probe
+# is in probe_int8_rigor.jl). Here we check exactness/accuracy vs BigFloat.
+
+using CUDACore, CUDA
+using Random, Printf, LinearAlgebra
+
+const gemmI8! = CUDA.CUBLAS.gemmEx!   # Int8*Int8 -> Int32, CUBLAS_COMPUTE_32I
+const B_BITS  = 7
+const BASE    = 2.0^B_BITS            # 128
+
+# Per-row (dim=2) scaling exponent so |ahat| <= 1/2.  Returns σ::CuArray (Mx1).
+function scale_exp(A; dims)
+    mx = maximum(abs.(A); dims=dims)
+    σ  = ceil.(log2.(max.(mx, floatmin(Float64)))) .+ 1.0
+    σ  = ifelse.(mx .== 0, 0.0, σ)     # zero rows/cols -> no scaling
+    return σ
+end
+
+# Split scaled matrix Ahat (|Ahat|<=1/2) into `s` INT8 slice matrices.
+function slices(Ahat, s)
+    D = Vector{CuArray{Int8,2}}(undef, s)
+    t = copy(Ahat)
+    for i in 1:s
+        t .*= BASE
+        di = round.(t)
+        D[i] = Int8.(di)
+        t .-= di
+    end
+    return D
+end
+
+# INT8-Ozaki product. s slices each side; include pairs with i+j <= T.
+function int8_ozaki(dA, dB; s=8, T=2s)
+    σA = scale_exp(dA; dims=2)          # M x 1
+    σB = scale_exp(dB; dims=1)          # 1 x N
+    Ahat = dA .* (2.0 .^ (.-σA))
+    Bhat = dB .* (2.0 .^ (.-σB))
+    DA = slices(Ahat, s)
+    DB = slices(Bhat, s)
+
+    M, N = size(dA, 1), size(dB, 2)
+    S = CUDA.zeros(Float64, M, N)
+    Cij = CUDA.zeros(Int32, M, N)
+    ngemm = 0
+    for i in 1:s, j in 1:s
+        i + j <= T || continue
+        fill!(Cij, Int32(0))
+        gemmI8!('N','N', Int32(1), DA[i], DB[j], Int32(0), Cij)
+        S .+= Float64.(Cij) .* (2.0^(-B_BITS*(i+j)))
+        ngemm += 1
+    end
+    C = S .* (2.0 .^ σA) .* (2.0 .^ σB)
+    return C, ngemm
+end
+
+function run(M, N, K; seed=1)
+    rng = MersenneTwister(seed)
+    A = randn(rng, Float64, M, K); B = randn(rng, Float64, K, N)
+    dA = CuArray(A); dB = CuArray(B)
+
+    P = setprecision(BigFloat, 250) do; BigFloat.(A) * BigFloat.(B); end
+    relerr(C) = Float64(maximum(abs.(BigFloat.(C) .- P)) / maximum(abs.(P)))
+
+    fp64_gpu = Array(dA * dB)                 # native FP64 gemm (round-to-nearest)
+    @printf("  M=%d N=%d K=%d\n", M, N, K)
+    @printf("    native FP64 gpu relerr = %.3e\n", relerr(fp64_gpu))
+    for (s, T) in [(4, 4), (6, 6), (8, 8), (8, 10), (8, 16)]
+        C, ng = int8_ozaki(dA, dB; s=s, T=T); CUDACore.synchronize()
+        @printf("    int8-ozaki s=%-2d T=%-2d (%2d gemms) relerr = %.3e\n",
+                s, T, ng, relerr(Array(C)))
+    end
+    println()
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()))
+println("eps(Float64) = ", eps(Float64), "\n")
+run(256, 256, 256)
+run(512, 512, 512)

--- a/experiments/cutile_probe/probe_int8_radius.jl
+++ b/experiments/cutile_probe/probe_int8_radius.jl
@@ -1,0 +1,64 @@
+# Radius matmul on INT8 tensor cores: a rigorous UPPER bound on U·V (U,V >= 0)
+# via ONE exact INT8 GEMM with ceil-rounded slices, vs the FP32 approach.
+#
+# Scale per row/col so Ũ,Ṽ <= 1/2; U8 = ceil(Ũ·2^7) (so U8·2^(σU-7) >= U); the
+# INT8 GEMM is exact (INT32), and Σ_k (U8·2^(σU-7))(V8·2^(σV-7)) >= Σ_k U·V.
+# We only need an upper bound (looser radius = slightly fatter ball), so the
+# 7-bit truncation is fine — and INT8 tensor cores beat FP32 ALUs ~3x.
+
+using CUDACore, CUDA, Random, Printf, LinearAlgebra
+const gemmI8! = CUDA.CUBLAS.gemmEx!
+
+# rigorous elementwise upper bound on U*V, U (M×K)>=0, V (K×N)>=0, via 1 INT8 gemm
+function int8_upper_product(dU, dV)
+    M_, K_ = size(dU); N_ = size(dV, 2)
+    mxU = maximum(dU; dims=2); mxV = maximum(dV; dims=1)
+    σU = ifelse.(mxU .== 0, 0.0, ceil.(log2.(max.(mxU, floatmin(Float64)))) .+ 1.0)
+    σV = ifelse.(mxV .== 0, 0.0, ceil.(log2.(max.(mxV, floatmin(Float64)))) .+ 1.0)
+    U8 = Int8.(ceil.(dU .* (2.0 .^ (7 .- σU))))    # in [0,64]
+    V8 = Int8.(ceil.(dV .* (2.0 .^ (7 .- σV))))
+    C  = CUDA.zeros(Int32, M_, N_)
+    gemmI8!('N','N', Int32(1), U8, V8, Int32(0), C)
+    return (Float64.(C) .* (2.0 .^ (σU .- 7)) .* (2.0 .^ (σV .- 7))) .* (1 + 4eps())
+end
+
+# FP32 reference upper bound (round-to-nearest + inflate)
+function fp32_upper_product(dU, dV)
+    K_ = size(dU, 2)
+    (Float64.(Float32.(dU) * Float32.(dV))) .* (1 + Float64(2K_+4) * Float64(eps(Float32)))
+end
+
+gt(f;nw=2,nr=6)=(for _ in 1:nw;f();CUDACore.synchronize();end;ts=Float64[];for _ in 1:nr;t0=time_ns();f();CUDACore.synchronize();push!(ts,(time_ns()-t0)/1e9);end;sort(ts)[cld(nr,2)])
+
+function run(M, N, K; seed=1)
+    rng = MersenneTwister(seed)
+    U = abs.(randn(rng, M, K)); V = abs.(randn(rng, K, N))   # nonneg
+    dU = CuArray(U); dV = CuArray(V)
+    b8 = Array(int8_upper_product(dU, dV)); CUDACore.synchronize()
+    bf = Array(fp32_upper_product(dU, dV))
+    setprecision(BigFloat, 200) do
+        true_p = BigFloat.(U) * BigFloat.(V)
+        ok8 = all(BigFloat.(b8) .>= true_p)
+        okf = all(BigFloat.(bf) .>= true_p)
+        loose8 = Float64(maximum(BigFloat.(b8) ./ true_p))
+        loosef = Float64(maximum(BigFloat.(bf) ./ true_p))
+        t8 = gt(() -> int8_upper_product(dU, dV))
+        tf = gt(() -> fp32_upper_product(dU, dV))
+        @printf("  %d^3: INT8 upper-bound=%s (max overest %.3fx, %.2f ms) | FP32=%s (%.4fx, %.2f ms)  speedup %.1fx\n",
+            M, ok8 ? "valid" : "INVALID", loose8, t8*1e3, okf ? "valid" : "INVALID", loosef, tf*1e3, tf/t8)
+        flush(stdout)
+    end
+end
+
+# speed only (no BigFloat), at larger sizes
+function speed(M, N, K)
+    rng = MersenneTwister(1); dU = CuArray(abs.(randn(rng,M,K))); dV = CuArray(abs.(randn(rng,K,N)))
+    t8 = gt(() -> int8_upper_product(dU, dV)); tf = gt(() -> fp32_upper_product(dU, dV))
+    @printf("  %d^3 speed: INT8 %.2f ms | FP32 %.2f ms  -> %.1fx faster\n", M, t8*1e3, tf*1e3, tf/t8); flush(stdout)
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()), "\n")
+println("-- rigor + looseness (BigFloat-checked) --")
+for s in (256, 512); run(s, s, s); end
+println("-- speed (INT8 tensor cores vs FP32 ALU) --")
+for s in (1024, 2048, 4096); speed(s, s, s); end

--- a/experiments/cutile_probe/probe_int8_rigor.jl
+++ b/experiments/cutile_probe/probe_int8_rigor.jl
@@ -1,0 +1,100 @@
+# Probe: rigorous INT8-Ozaki ball GEMM — verified enclosure of the exact A*B.
+#
+# Center: truncated INT8-Ozaki (pairs i+j <= T), computed in FP64.
+# Radius: a-priori bound on
+#   (a) dropped slice-pairs (i+j > T) and slice residual, and
+#   (b) FP64 recombination rounding.
+# Since INT8 products are EXACT, the true product is
+#   A*B = 2^(σA+σB) Σ_{all i,j} 2^(-7(i+j)) (DA_i · DB_j)   (exact),
+# so the error is purely the omitted terms + FP64 add rounding — both bounded.
+#
+# i+j > T  ==>  i > m or j > m  (m = floor(T/2)), hence
+#   |A*B - center| <= 2^(σA+σB) ( loA·fullB + fullA·loB )
+# with loA = Σ_{i>m} 2^(-7i)|DA_i| + residual,  fullA = Σ_i 2^(-7i)|DA_i| + residual.
+
+using CUDACore, CUDA
+using Random, Printf, LinearAlgebra
+
+const gemmI8! = CUDA.CUBLAS.gemmEx!
+const B_BITS  = 7
+const BASE    = 2.0^B_BITS
+const U        = eps(Float64)
+
+scale_exp(A; dims) = (mx = maximum(abs.(A); dims=dims);
+    ifelse.(mx .== 0, 0.0, ceil.(log2.(max.(mx, floatmin(Float64)))) .+ 1.0))
+
+# Return slice matrices AND the final residual t (Ahat = Σ D_i 2^-7i + t·2^-7s).
+function slices(Ahat, s)
+    D = Vector{CuArray{Int8,2}}(undef, s)
+    t = copy(Ahat)
+    for i in 1:s
+        t .*= BASE; di = round.(t); D[i] = Int8.(di); t .-= di
+    end
+    return D, t
+end
+
+function int8_ozaki_ball(dA, dB; s=8, T=8)
+    M, N, K = size(dA,1), size(dB,2), size(dA,2)
+    σA = scale_exp(dA; dims=2); σB = scale_exp(dB; dims=1)
+    DA, _ = slices(dA .* (2.0 .^ (.-σA)), s)
+    DB, _ = slices(dB .* (2.0 .^ (.-σB)), s)
+
+    # --- center: kept pairs i+j <= T, accumulated in FP64 ---
+    S = CUDA.zeros(Float64, M, N); Cij = CUDA.zeros(Int32, M, N); ngemm = 0
+    for i in 1:s, j in 1:s
+        i + j <= T || continue
+        fill!(Cij, Int32(0)); gemmI8!('N','N', Int32(1), DA[i], DB[j], Int32(0), Cij)
+        S .+= Float64.(Cij) .* (2.0^(-B_BITS*(i+j))); ngemm += 1
+    end
+    scaleA = 2.0 .^ σA; scaleB = 2.0 .^ σB
+    center = (S .* scaleA) .* scaleB
+
+    # --- radius ---
+    m = fld(T, 2)
+    resid = 2.0^(-B_BITS*s - 1)            # bound on |slice residual| (scaled units)
+    fullA = CUDA.zeros(Float64, M, K); loA = CUDA.zeros(Float64, M, K)
+    fullB = CUDA.zeros(Float64, K, N); loB = CUDA.zeros(Float64, K, N)
+    for i in 1:s
+        w = 2.0^(-B_BITS*i)
+        fullA .+= w .* abs.(Float64.(DA[i])); fullB .+= w .* abs.(Float64.(DB[i]))
+        if i > m
+            loA .+= w .* abs.(Float64.(DA[i])); loB .+= w .* abs.(Float64.(DB[i]))
+        end
+    end
+    fullA .+= resid; fullB .+= resid; loA .+= resid; loB .+= resid
+
+    # two nonneg matmuls; inflate to a rigorous upper bound for FP64 gemm rounding
+    infl = 1.0 + (K + 2) * U
+    bound = (loA * fullB) .* infl
+    bound .+= (fullA * loB) .* infl
+    dropped = ((bound .* scaleA) .* scaleB) .* infl
+
+    rec = Float64(ngemm + 3) * U .* abs.(center)     # recombination rounding
+    radius = (dropped .+ rec) .* (1.0 + 8U)          # small safety margin
+    return center, radius, ngemm
+end
+
+function run(M, N, K; s=8, T=8, seed=1)
+    rng = MersenneTwister(seed)
+    A = randn(rng, Float64, M, K); B = randn(rng, Float64, K, N)
+    dA = CuArray(A); dB = CuArray(B)
+    c, r, ng = int8_ozaki_ball(dA, dB; s=s, T=T); CUDACore.synchronize()
+    mC = Array(c); rC = Array(r)
+    setprecision(BigFloat, 300) do
+        P = BigFloat.(A) * BigFloat.(B)
+        lo = BigFloat.(mC) .- BigFloat.(rC); hi = BigFloat.(mC) .+ BigFloat.(rC)
+        inside = all(lo .<= P .<= hi)
+        ctr_err = maximum(abs.(BigFloat.(mC) .- P))
+        relrad  = Float64(maximum(BigFloat.(rC)) / maximum(abs.(P)))
+        tightness = Float64(maximum(BigFloat.(rC)) / max(ctr_err, eps(BigFloat)))
+        @printf("  M=%d N=%d K=%d  s=%d T=%d (%d gemms)\n", M, N, K, s, T, ng)
+        @printf("    ENCLOSURE: %s   center max err = %.2e   radius (rel) = %.2e   radius/err = %.1fx\n",
+            inside ? "OK" : "FAILED", Float64(ctr_err), relrad, tightness)
+    end
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()), "\n")
+run(256, 256, 256; T=8)
+run(256, 256, 256; T=10)
+run(512, 512, 512; T=8)
+run(512, 512, 512; T=10)

--- a/experiments/cutile_probe/probe_int8_rigor_tight.jl
+++ b/experiments/cutile_probe/probe_int8_rigor_tight.jl
@@ -1,0 +1,96 @@
+# Task 1: TIGHT rigorous radius for the INT8-Ozaki midpoint product.
+#
+# The loose bound (probe_int8_rigor.jl) used  loA·fullB + fullA·loB, which pairs
+# every i>m slice with ALL j — over-counting many pairs with i+j<=T that are NOT
+# dropped (e.g. (i=6,j=1) for T=10). Those non-dropped, high-magnitude terms
+# dominated the bound (~1e6x the true error).
+#
+# Tight bound: the dropped set is exactly {(i,j): i+j>T}, so
+#     Σ_{i+j>T} x_i y_j  =  Σ_i x_i · ( Σ_{j>T-i} y_j )  =  Σ_i x_i · Ytail_{T-i}
+# with x_i = 2^-7i|DA_i|, y_j = 2^-7j|DB_j|.  Computed in FP32 (it's only an upper
+# bound) — a handful of GEMMs.  Plus: rigorous recombination bound (Σ|terms|·u)
+# and a residual bound (row/col sums, no GEMM).
+
+using CUDACore, CUDA
+using Random, Printf, LinearAlgebra
+
+const gemmI8! = CUDA.CUBLAS.gemmEx!
+const B_BITS = 7; const BASE = 2.0^B_BITS
+const U64 = eps(Float64); const U32 = Float64(eps(Float32))
+
+scale_exp(A; dims) = (mx = maximum(abs.(A); dims=dims);
+    ifelse.(mx .== 0, 0.0, ceil.(log2.(max.(mx, floatmin(Float64)))) .+ 1.0))
+function slices(Ahat, s)
+    D = Vector{CuArray{Int8,2}}(undef, s); t = copy(Ahat)
+    for i in 1:s; t .*= BASE; di = round.(t); D[i] = Int8.(di); t .-= di; end
+    return D
+end
+
+function ozaki_midpoint_tight(dmA, dmB; s=8, T=10)
+    M_, N_, K_ = size(dmA,1), size(dmB,2), size(dmA,2)
+    σA = scale_exp(dmA; dims=2); σB = scale_exp(dmB; dims=1)
+    scaleA = 2.0 .^ σA; scaleB = 2.0 .^ σB
+    DA = slices(dmA .* (2.0 .^ (.-σA)), s); DB = slices(dmB .* (2.0 .^ (.-σB)), s)
+
+    # center + Σ|terms| for the recombination bound
+    S    = CUDA.zeros(Float64, M_, N_)
+    Sabs = CUDA.zeros(Float64, M_, N_)
+    Cij  = CUDA.zeros(Int32, M_, N_); ng = 0
+    for i in 1:s, j in 1:s
+        i+j <= T || continue
+        fill!(Cij, Int32(0)); gemmI8!('N','N', Int32(1), DA[i], DB[j], Int32(0), Cij)
+        term = Float64.(Cij) .* (2.0^(-B_BITS*(i+j)))
+        S .+= term; Sabs .+= abs.(term); ng += 1
+    end
+    m = (S .* scaleA) .* scaleB
+
+    # tight dropped-tail bound in FP32
+    xs = [Float32(2.0^(-B_BITS*i)) .* abs.(Float32.(DA[i])) for i in 1:s]   # M×K
+    ys = [Float32(2.0^(-B_BITS*j)) .* abs.(Float32.(DB[j])) for j in 1:s]   # K×N
+    Ytail = Vector{CuArray{Float32,2}}(undef, s+1)                # Ytail[p+1]=Σ_{j>p} y_j
+    Ytail[s+1] = CUDA.zeros(Float32, K_, N_)
+    for p in s-1:-1:0; Ytail[p+1] = Ytail[p+2] .+ ys[p+1]; end
+    bnd32 = CUDA.zeros(Float32, M_, N_); ngb = 0
+    for i in 1:s
+        p = T - i
+        p >= s && continue          # no dropped j for this i
+        bnd32 .+= xs[i] * Ytail[p+1]    # FP32 GEMM
+        ngb += 1
+    end
+    infl = 1.0 + Float64(2K_ + 8) * U32
+    tail = (Float64.(bnd32) .* infl)
+
+    # residual bound (slice leftover beyond s): 2^-7s-1 · (rowsumA + colsumB)
+    fullA32 = reduce(.+, xs); fullB32 = reduce(.+, ys)
+    rowsumA = Float64.(sum(fullA32; dims=2))      # M×1
+    colsumB = Float64.(sum(fullB32; dims=1))      # 1×N
+    resid = (2.0^(-B_BITS*s - 1)) .* (rowsumA .+ colsumB) .* (1.0 + Float64(2K_)*U32)
+
+    # assemble ρ (all rounded up generously)
+    dropped = ((tail .+ resid) .* scaleA) .* scaleB
+    recomb  = Float64(ng + 3) * U64 .* ((Sabs .* scaleA) .* scaleB)
+    ρ = (dropped .+ recomb) .* (1.0 + 8U64)
+    return m, ρ, ng, ngb
+end
+
+function run(M, N, K; s=8, T=10, seed=1)
+    rng = MersenneTwister(seed)
+    A = randn(rng, Float64, M, K); B = randn(rng, Float64, K, N)
+    dA = CuArray(A); dB = CuArray(B)
+    m, ρ, ng, ngb = ozaki_midpoint_tight(dA, dB; s=s, T=T); CUDACore.synchronize()
+    mC = Array(m); rC = Array(ρ)
+    setprecision(BigFloat, 300) do
+        P = BigFloat.(A) * BigFloat.(B)
+        lo = BigFloat.(mC) .- BigFloat.(rC); hi = BigFloat.(mC) .+ BigFloat.(rC)
+        inside = all(lo .<= P .<= hi)
+        ctr_err = maximum(abs.(BigFloat.(mC) .- P))
+        relrad  = Float64(maximum(BigFloat.(rC)) / maximum(abs.(P)))
+        ratio   = Float64(maximum(BigFloat.(rC)) / max(ctr_err, eps(BigFloat)))
+        @printf("  %d^3 s=%d T=%d (%d int8 + %d fp32 gemms): ENCLOSE=%s  ctr_err=%.2e  radius_rel=%.2e  radius/err=%.1fx\n",
+            M, s, T, ng, ngb, inside ? "OK" : "FAIL", Float64(ctr_err), relrad, ratio)
+    end
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()), "\n")
+for T in (8, 10, 12); run(256, 256, 256; T=T); end
+for T in (8, 10, 12); run(512, 512, 512; T=T); end

--- a/experiments/cutile_probe/probe_int8_schemeII.jl
+++ b/experiments/cutile_probe/probe_int8_schemeII.jl
@@ -1,0 +1,86 @@
+# Probe: Ozaki Scheme II (CRT) — INT8 GEMM, one per modulus, reconstructed via
+# the Chinese Remainder Theorem. arXiv:2504.08009.
+#
+# Scale A,B to integer matrices A' = round(2^k ahat), B' = round(2^k bhat)
+# (per-row/col power-of-two scaling, ahat,bhat in [-1/2,1/2]). The exact integer
+# product X = A'·B' has |X| <= K·2^(2k-2) = q.  Pick s coprime moduli m_t with
+# M = Πm_t > 2q.  For each t:
+#     A'_t = balanced(A' mod m_t) in INT8,  B'_t likewise,
+#     C_t  = A'_t · B'_t      (exact INT8->INT32 tensor-core GEMM),
+#     r_t  = C_t mod m_t  ≡  X mod m_t .
+# CRT (Garner) reconstructs X exactly from {r_t}; then C = 2^(σA+σB-2k) X.
+#
+# Cost: s GEMMs (vs Scheme-I's ~T^2/2 = 43). Reconstruction here is on CPU
+# (Garner + Int128) — O(M·N·s^2), independent of K; GPU-side is future work.
+
+using CUDACore, CUDA
+using Random, Printf, LinearAlgebra
+
+const MODULI  = Int[256,255,253,251,247,239,233,229,227,223,217,211,199,197,193]
+const gemmI8! = CUDA.CUBLAS.gemmEx!
+
+scale_exp(A; dims) = (mx = maximum(abs.(A); dims=dims);
+    ifelse.(mx .== 0, 0.0, ceil.(log2.(max.(mx, floatmin(Float64)))) .+ 1.0))
+
+# Balanced residue of an Int64 matrix mod m, as INT8 in [-128,127].
+function residue_i8(Ap, m)
+    r  = mod.(Ap, Int64(m))
+    rb = ifelse.(2 .* r .>= m, r .- m, r)   # -> [-m/2, m/2)
+    return Int8.(rb)
+end
+
+function schemeII(A, B; s=15, k=53)
+    M_, N_ = size(A,1), size(B,2)
+    dA = CuArray(A); dB = CuArray(B)
+    σA = scale_exp(dA; dims=2); σB = scale_exp(dB; dims=1)
+    Ap = Int64.(round.((2.0^k) .* (dA .* (2.0 .^ (.-σA)))))   # |A'| <= 2^(k-1)
+    Bp = Int64.(round.((2.0^k) .* (dB .* (2.0 .^ (.-σB)))))
+    mods = MODULI[1:s]
+
+    R = Vector{Matrix{Int64}}(undef, s)
+    Cij = CUDA.zeros(Int32, M_, N_)
+    for (t,m) in enumerate(mods)
+        At = residue_i8(Ap, m); Bt = residue_i8(Bp, m)
+        fill!(Cij, Int32(0))
+        gemmI8!('N','N', Int32(1), At, Bt, Int32(0), Cij)
+        R[t] = Int64.(Array(mod.(Cij, Int32(m))))     # r_t = X mod m_t
+    end
+
+    # --- Garner mixed-radix reconstruction (CPU) ---
+    minv = [j < t ? invmod(mods[j], mods[t]) : 0 for j in 1:s, t in 1:s]
+    c = Vector{Matrix{Int64}}(undef, s)
+    for t in 1:s
+        ct = copy(R[t])
+        for j in 1:t-1
+            ct = mod.((ct .- c[j]) .* minv[j,t], mods[t])
+        end
+        c[t] = ct
+    end
+    Mbig = prod(Int128.(mods))
+    X = Int128.(c[s])
+    for t in s-1:-1:1
+        X = X .* Int128(mods[t]) .+ c[t]
+    end
+    X = ifelse.(X .>= Mbig ÷ 2, X .- Mbig, X)        # balanced -> signed
+    C = Float64.(X) .* (2.0^(-2k)) .* Array(2.0 .^ σA) .* Array(2.0 .^ σB)
+    return C, length(mods)
+end
+
+function run(M, N, K; ks=[53])
+    rng = MersenneTwister(1)
+    A = randn(rng, Float64, M, K); B = randn(rng, Float64, K, N)
+    P = setprecision(BigFloat, 300) do; BigFloat.(A) * BigFloat.(B); end
+    relerr(C) = Float64(maximum(abs.(BigFloat.(C) .- P)) / maximum(abs.(P)))
+    @printf("  M=%d N=%d K=%d   (native FP64 gpu relerr = %.2e)\n",
+            M, N, K, relerr(Array(CuArray(A)*CuArray(B))))
+    for k in ks, s in [12, 13, 14, 15]
+        C, ng = schemeII(A, B; s=s, k=k)
+        @printf("    Scheme II  s=%-2d k=%-2d (%2d gemms)  relerr = %.3e\n", s, k, ng, relerr(C))
+    end
+    println()
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()))
+println("eps(Float64) = ", eps(Float64), "\n")
+run(256, 256, 256)
+run(512, 512, 512)

--- a/experiments/cutile_probe/probe_int8_streams.jl
+++ b/experiments/cutile_probe/probe_int8_streams.jl
@@ -1,0 +1,98 @@
+# Where does INT8-Ozaki time actually go, and can the GEMMs run concurrently?
+#
+# Breakdown at a fixed size:
+#   (a) split cost (FP64 -> INT8 slices)
+#   (b) 43 INT8 GEMMs only, sequential (one stream)
+#   (c) 43 INT8 GEMMs only, spread over N streams (test concurrency)
+#   (d) full pipeline: GEMM + FP64 recombination interleaved (current probe)
+#   (e) FP64 recombination only
+
+using CUDACore, CUDA
+using Random, Printf
+
+const gemmI8! = CUDA.CUBLAS.gemmEx!
+const B_BITS = 7; const BASE = 2.0^B_BITS
+
+scale_exp(A; dims) = (mx = maximum(abs.(A); dims=dims);
+    ifelse.(mx .== 0, 0.0, ceil.(log2.(max.(mx, floatmin(Float64)))) .+ 1.0))
+function slices(Ahat, s)
+    D = Vector{CuArray{Int8,2}}(undef, s); t = copy(Ahat)
+    for i in 1:s; t .*= BASE; di = round.(t); D[i] = Int8.(di); t .-= di; end
+    return D
+end
+
+function timeit(f; nwarm=3, nrep=8)
+    for _ in 1:nwarm; f(); CUDACore.synchronize(); end
+    ts = Float64[]
+    for _ in 1:nrep
+        t0 = time_ns(); f(); CUDACore.synchronize(); push!(ts, (time_ns()-t0)/1e9)
+    end
+    return sort(ts)[cld(length(ts),2)]
+end
+
+function run(M, N, K; s=8, T=10)
+    rng = MersenneTwister(1)
+    dA = CuArray(randn(rng, Float64, M, K)); dB = CuArray(randn(rng, Float64, K, N))
+    σA = scale_exp(dA; dims=2); σB = scale_exp(dB; dims=1)
+    DA = slices(dA .* (2.0 .^ (.-σA)), s); DB = slices(dB .* (2.0 .^ (.-σB)), s)
+    pairs = [(i,j) for i in 1:s for j in 1:s if i+j <= T]
+    ng = length(pairs)
+
+    # Pre-allocated Int32 output buffers (one per pair, for the concurrent case)
+    Couts = [CUDA.zeros(Int32, M, N) for _ in 1:ng]
+    Cij   = CUDA.zeros(Int32, M, N)
+    S     = CUDA.zeros(Float64, M, N)
+
+    t_split = timeit(() -> (slices(dA .* (2.0 .^ (.-σA)), s); slices(dB .* (2.0 .^ (.-σB)), s)))
+
+    # (b) GEMMs only, sequential, default stream
+    t_seq = timeit(function ()
+        for (p,(i,j)) in enumerate(pairs)
+            gemmI8!('N','N', Int32(1), DA[i], DB[j], Int32(0), Couts[p])
+        end
+    end)
+
+    # (c) GEMMs only, spread over nstreams
+    function gemms_streams(nstreams)
+        streams = [CuStream() for _ in 1:nstreams]
+        for (p,(i,j)) in enumerate(pairs)
+            CUDA.stream!(streams[(p % nstreams) + 1]) do
+                gemmI8!('N','N', Int32(1), DA[i], DB[j], Int32(0), Couts[p])
+            end
+        end
+        foreach(CUDA.synchronize, streams)
+    end
+    t_str4 = timeit(() -> gemms_streams(4))
+    t_str8 = timeit(() -> gemms_streams(8))
+
+    # (d) full pipeline (current probe): gemm + FP64 accumulate interleaved
+    t_full = timeit(function ()
+        fill!(S, 0.0)
+        for (i,j) in pairs
+            fill!(Cij, Int32(0)); gemmI8!('N','N', Int32(1), DA[i], DB[j], Int32(0), Cij)
+            S .+= Float64.(Cij) .* (2.0^(-B_BITS*(i+j)))
+        end
+    end)
+
+    # (e) recombination only (GEMM results precomputed)
+    t_rec = timeit(function ()
+        fill!(S, 0.0)
+        for (p,(i,j)) in enumerate(pairs)
+            S .+= Float64.(Couts[p]) .* (2.0^(-B_BITS*(i+j)))
+        end
+    end)
+
+    @printf("  M=%d N=%d K=%d   %d gemms\n", M, N, K, ng)
+    @printf("    split (FP64->INT8)        %7.2f ms\n", t_split*1e3)
+    @printf("    %d GEMMs, sequential       %7.2f ms\n", ng, t_seq*1e3)
+    @printf("    %d GEMMs, 4 streams        %7.2f ms\n", ng, t_str4*1e3)
+    @printf("    %d GEMMs, 8 streams        %7.2f ms\n", ng, t_str8*1e3)
+    @printf("    FP64 recombination only   %7.2f ms\n", t_rec*1e3)
+    @printf("    full (gemm+recomb interl) %7.2f ms\n", t_full*1e3)
+    println()
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()), "\n")
+run(1024, 1024, 1024)
+run(2048, 2048, 2048)
+run(4096, 4096, 4096)

--- a/experiments/cutile_probe/probe_int8_vs_cpu.jl
+++ b/experiments/cutile_probe/probe_int8_vs_cpu.jl
@@ -1,0 +1,60 @@
+# INT8-Ozaki (GPU) vs CPU: raw FP64 GEMM and the rigorous CPU MMul4.
+# All produce an FP64-accurate product; INT8-Ozaki and MMul4 are rigorous.
+
+using CUDACore, CUDA
+using BallArithmetic
+using Random, Printf, LinearAlgebra
+
+const gemmI8! = CUDA.CUBLAS.gemmEx!
+const B_BITS = 7; const BASE = 2.0^B_BITS
+scale_exp(A; dims) = (mx = maximum(abs.(A); dims=dims);
+    ifelse.(mx .== 0, 0.0, ceil.(log2.(max.(mx, floatmin(Float64)))) .+ 1.0))
+function slices(Ahat, s)
+    D = Vector{CuArray{Int8,2}}(undef, s); t = copy(Ahat)
+    for i in 1:s; t .*= BASE; di = round.(t); D[i] = Int8.(di); t .-= di; end
+    return D
+end
+function int8_ozaki(dA, dB; s=8, T=2s)
+    σA = scale_exp(dA; dims=2); σB = scale_exp(dB; dims=1)
+    DA = slices(dA .* (2.0 .^ (.-σA)), s); DB = slices(dB .* (2.0 .^ (.-σB)), s)
+    M, N = size(dA,1), size(dB,2)
+    S = CUDA.zeros(Float64, M, N); Cij = CUDA.zeros(Int32, M, N)
+    for i in 1:s, j in 1:s
+        i+j <= T || continue
+        fill!(Cij, Int32(0)); gemmI8!('N','N', Int32(1), DA[i], DB[j], Int32(0), Cij)
+        S .+= Float64.(Cij) .* (2.0^(-B_BITS*(i+j)))
+    end
+    return (S .* (2.0 .^ σA)) .* (2.0 .^ σB)
+end
+
+gtime(f; nw=3, nr=8) = (for _ in 1:nw; f(); CUDACore.synchronize(); end;
+    ts=Float64[]; for _ in 1:nr; t0=time_ns(); f(); CUDACore.synchronize(); push!(ts,(time_ns()-t0)/1e9); end; sort(ts)[cld(nr,2)])
+ctime(f; nw=2, nr=5) = (for _ in 1:nw; f(); end;
+    ts=Float64[]; for _ in 1:nr; t0=time_ns(); f(); push!(ts,(time_ns()-t0)/1e9); end; sort(ts)[cld(nr,2)])
+
+function run(M, N, K; seed=1)
+    rng = MersenneTwister(seed)
+    A = randn(rng, Float64, M, K); B = randn(rng, Float64, K, N)
+    dA = CuArray(A); dB = CuArray(B)
+    Ab = BallMatrix(A); Bb = BallMatrix(B)        # zero-radius ball matrices
+
+    t_cpu_gemm = ctime(() -> A * B)
+    t_cpu_mmul4 = ctime(() -> BallArithmetic.MMul4(Ab, Bb))
+    t_gpu_t8  = gtime(() -> int8_ozaki(dA, dB; s=8, T=8))
+    t_gpu_t10 = gtime(() -> int8_ozaki(dA, dB; s=8, T=10))
+
+    @printf("  %d^3\n", M)
+    @printf("    CPU  FP64 gemm (OpenBLAS, non-rigorous)  %8.2f ms\n", t_cpu_gemm*1e3)
+    @printf("    CPU  MMul4 (rigorous ball)               %8.2f ms\n", t_cpu_mmul4*1e3)
+    @printf("    GPU  INT8-Ozaki T=8  (rigorous, 4e-14)   %8.2f ms   %.1fx CPU-MMul4 | %.1fx CPU-gemm\n",
+            t_gpu_t8*1e3, t_cpu_mmul4/t_gpu_t8, t_cpu_gemm/t_gpu_t8)
+    @printf("    GPU  INT8-Ozaki T=10 (rigorous, 5e-16)   %8.2f ms   %.1fx CPU-MMul4 | %.1fx CPU-gemm\n",
+            t_gpu_t10*1e3, t_cpu_mmul4/t_gpu_t10, t_cpu_gemm/t_gpu_t10)
+    println()
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()))
+println("CPU BLAS threads: ", BLAS.get_num_threads(), "\n")
+for s in [1024, 2048, 4096]
+    run(s, s, s)
+end

--- a/experiments/cutile_probe/probe_mmul4.jl
+++ b/experiments/cutile_probe/probe_mmul4.jl
@@ -1,0 +1,122 @@
+# End-to-end probe of a full MMul4 kernel on cuTile.
+#
+# Reproduces the MMul4 algorithm from src/types/MMul/MMul4.jl on the GPU
+# using elementwise tile ops inside @fpmode scopes, and compares against
+# the CPU implementation entry by entry.
+
+using CUDACore
+using cuTile: cuTile
+import cuTile as ct
+using Random, Printf, Pkg
+Pkg.activate(joinpath(@__DIR__, "..", ".."); io=devnull)  # load BallArithmetic
+using BallArithmetic
+Pkg.activate(@__DIR__; io=devnull)                       # back to probe env
+
+# One thread block computes one (tm × tn) tile of the output mid/rad.
+# Implements MMul4(BallMatrix, BallMatrix) -> BallMatrix.
+function _mmul4_kernel!(mC::ct.TileArray{T,2}, rC::ct.TileArray{T,2},
+                       mA::ct.TileArray{T,2}, rA::ct.TileArray{T,2},
+                       mB::ct.TileArray{T,2}, rB::ct.TileArray{T,2},
+                       tm::Int, tn::Int) where {T}
+    bid_m = ct.bid(1)
+    bid_n = ct.bid(2)
+    K = size(mA, 2)
+
+    acc_up = zeros(T, tm, tn)   # will become C2 = (mA*mB)_up + rC
+    acc_r  = zeros(T, tm, tn)   # rC = |mA|·rB + rA·(|mB|+rB), all RoundUp
+
+    ct.@fpmode rounding_mode=ct.Rounding.PosInf flush_to_zero=false begin
+        for k in Int32(1):Int32(K)
+            mA_col = ct.load(mA; index=(bid_m, k), shape=(tm, 1), padding_mode=ct.PaddingMode.Zero)
+            mB_row = ct.load(mB; index=(k, bid_n), shape=(1, tn), padding_mode=ct.PaddingMode.Zero)
+            rA_col = ct.load(rA; index=(bid_m, k), shape=(tm, 1), padding_mode=ct.PaddingMode.Zero)
+            rB_row = ct.load(rB; index=(k, bid_n), shape=(1, tn), padding_mode=ct.PaddingMode.Zero)
+
+            absA = cuTile.Intrinsics.absf(mA_col)
+            absB = cuTile.Intrinsics.absf(mB_row)
+            acc_up = acc_up + mA_col * mB_row
+            acc_r  = acc_r  + absA * rB_row + rA_col * (absB + rB_row)
+        end
+        acc_up = acc_up + acc_r       # C2
+    end
+
+    acc_dn = zeros(T, tm, tn)
+    ct.@fpmode rounding_mode=ct.Rounding.NegInf flush_to_zero=false begin
+        for k in Int32(1):Int32(K)
+            mA_col = ct.load(mA; index=(bid_m, k), shape=(tm, 1), padding_mode=ct.PaddingMode.Zero)
+            mB_row = ct.load(mB; index=(k, bid_n), shape=(1, tn), padding_mode=ct.PaddingMode.Zero)
+            acc_dn = acc_dn + mA_col * mB_row
+        end
+        acc_dn = acc_dn - acc_r        # C1
+    end
+
+    ct.@fpmode rounding_mode=ct.Rounding.PosInf flush_to_zero=false begin
+        mid_tile = (acc_dn + acc_up) * T(0.5)
+        rad_tile = mid_tile - acc_dn
+        ct.store(mC; index=(bid_m, bid_n), tile=mid_tile)
+        ct.store(rC; index=(bid_m, bid_n), tile=rad_tile)
+    end
+    return nothing
+end
+
+function mmul4_gpu(mA::Matrix{T}, rA::Matrix{T}, mB::Matrix{T}, rB::Matrix{T};
+                   tm=16, tn=16) where {T}
+    dmA = CuArray(mA); drA = CuArray(rA)
+    dmB = CuArray(mB); drB = CuArray(rB)
+    dmC = CuArray{T}(undef, size(mA, 1), size(mB, 2))
+    drC = CuArray{T}(undef, size(mA, 1), size(mB, 2))
+    grid = (cld(size(mA,1), tm), cld(size(mB,2), tn))
+    @cuda backend=cuTile blocks=grid _mmul4_kernel!(dmC, drC, dmA, drA, dmB, drB,
+        ct.Constant(tm), ct.Constant(tn))
+    CUDACore.synchronize()
+    return Array(dmC), Array(drC)
+end
+
+function check(::Type{T}, M, N, K; tm=16, tn=16) where {T}
+    rng = MersenneTwister(42)
+    mA = rand(rng, T, M, K) .- T(0.5)
+    rA = rand(rng, T, M, K) .* T(1e-3)
+    mB = rand(rng, T, K, N) .- T(0.5)
+    rB = rand(rng, T, K, N) .* T(1e-3)
+
+    A = BallMatrix(mA, rA)
+    B = BallMatrix(mB, rB)
+    C_cpu = A * B   # MMul4 CPU
+    mC_cpu, rC_cpu = mid(C_cpu), rad(C_cpu)
+
+    mC_gpu, rC_gpu = mmul4_gpu(mA, rA, mB, rB; tm=tm, tn=tn)
+
+    cpu_lo = mC_cpu .- rC_cpu
+    cpu_hi = mC_cpu .+ rC_cpu
+    gpu_lo = mC_gpu .- rC_gpu
+    gpu_hi = mC_gpu .+ rC_gpu
+
+    gpu_encloses_cpu = all(gpu_lo .<= cpu_lo) && all(cpu_hi .<= gpu_hi)
+    cpu_encloses_gpu = all(cpu_lo .<= gpu_lo) && all(gpu_hi .<= cpu_hi)
+    overlap = all(max.(gpu_lo, cpu_lo) .<= min.(gpu_hi, cpu_hi))
+
+    mid_diff = maximum(abs.(mC_gpu .- mC_cpu))
+    rad_ratio_max = maximum(rC_gpu ./ max.(rC_cpu, eps(T)))
+    rad_ratio_min = minimum(rC_gpu ./ max.(rC_cpu, eps(T)))
+
+    println(@sprintf("  %s  M=%d N=%d K=%d tm=%d tn=%d", T, M, N, K, tm, tn))
+    println(@sprintf("    overlap (every entry)         : %s", overlap))
+    println(@sprintf("    GPU encloses CPU              : %s", gpu_encloses_cpu))
+    println(@sprintf("    CPU encloses GPU              : %s", cpu_encloses_gpu))
+    println(@sprintf("    |mC_gpu - mC_cpu|_inf         : %g", mid_diff))
+    println(@sprintf("    rC_gpu / rC_cpu range         : [%g, %g]",
+                     rad_ratio_min, rad_ratio_max))
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()))
+println()
+
+println("--- Float32 ---")
+check(Float32, 16, 16, 64;  tm=16, tn=16)
+check(Float32, 64, 64, 256; tm=16, tn=16)
+check(Float32, 64, 64, 256; tm=32, tn=32)
+
+println("\n--- Float64 ---")
+check(Float64, 16, 16, 64;  tm=16, tn=16)
+check(Float64, 64, 64, 256; tm=16, tn=16)
+check(Float64, 64, 64, 256; tm=32, tn=32)

--- a/experiments/cutile_probe/probe_ozaki.jl
+++ b/experiments/cutile_probe/probe_ozaki.jl
@@ -1,0 +1,98 @@
+# Probe: Ozaki-style splitting for a more-accurate GPU GEMM.
+#
+# Idea: split Float32 A, B into 12-bit "high" and "low" halves via Veltkamp.
+# Each per-element product A_hi[i,k] * B_hi[k,j] has ≤ 24 mantissa bits
+# (12+12), so the per-multiply rounding error is zero in Float32. Only the
+# K-fold accumulation contributes rounding error. Four CUBLAS GEMMs:
+#   C ≈ A_hi*B_hi + A_hi*B_lo + A_lo*B_hi + A_lo*B_lo
+#
+# Pass criterion: |C_ozaki - true| should be measurably smaller than
+# |C_naive - true|, where C_naive is a single Float32 CUBLAS GEMM and
+# `true` is BigFloat A*B rounded back to Float32.
+
+using CUDACore
+using Random, Printf, LinearAlgebra
+
+const SPLIT_BITS = 12
+const SPLIT_C    = Float32(2^SPLIT_BITS + 1)
+
+# Veltkamp split on the device. After this:
+#   * A = A_hi + A_lo exactly (Float32),
+#   * A_hi, A_lo each have ≤ (24 − SPLIT_BITS) = 12 mantissa bits.
+function veltkamp_split_gpu(A::CuArray{Float32})
+    γ    = SPLIT_C .* A
+    A_hi = γ .- (γ .- A)
+    A_lo = A .- A_hi
+    return A_hi, A_lo
+end
+
+function ozaki_gemm(dA::CuArray{Float32}, dB::CuArray{Float32})
+    A_hi, A_lo = veltkamp_split_gpu(dA)
+    B_hi, B_lo = veltkamp_split_gpu(dB)
+    return (A_hi * B_hi) .+ (A_hi * B_lo) .+ (A_lo * B_hi) .+ (A_lo * B_lo)
+end
+
+naive_gemm(dA::CuArray{Float32}, dB::CuArray{Float32}) = dA * dB
+
+# Ground truth: BigFloat matmul, rounded back to Float32 for comparison.
+function reference(A::Matrix{Float32}, B::Matrix{Float32})
+    setprecision(BigFloat, 128) do
+        Float32.(BigFloat.(A) * BigFloat.(B))
+    end
+end
+
+# Reference at full BigFloat precision (no rounding back), for the bound.
+function reference_big(A::Matrix{Float32}, B::Matrix{Float32})
+    setprecision(BigFloat, 128) do
+        BigFloat.(A) * BigFloat.(B)
+    end
+end
+
+function run_probe(M, N, K; seed=42)
+    rng = MersenneTwister(seed)
+    A = randn(rng, Float32, M, K)
+    B = randn(rng, Float32, K, N)
+    dA = CuArray(A); dB = CuArray(B)
+
+    C_naive_d = naive_gemm(dA, dB)
+    C_ozaki_d = ozaki_gemm(dA, dB)
+    CUDACore.synchronize()
+    C_naive = Array(C_naive_d)
+    C_ozaki = Array(C_ozaki_d)
+
+    C_true_big = reference_big(A, B)
+
+    err_naive_inf = maximum(abs.(BigFloat.(C_naive) .- C_true_big))
+    err_ozaki_inf = maximum(abs.(BigFloat.(C_ozaki) .- C_true_big))
+
+    # Higham-style entrywise bound on a Float32 GEMM with IEEE rounding:
+    #   |fl(A*B) - A*B|_ij ≤ K * eps(Float32) * (|A|·|B|)_ij  (leading order)
+    AB_abs = abs.(BigFloat.(A)) * abs.(BigFloat.(B))
+    higham = Float32(K) * eps(Float32) .* AB_abs
+    bound_max = maximum(higham)
+
+    @printf("  M=%d N=%d K=%d\n", M, N, K)
+    @printf("    naive Float32 max err     = %g\n", Float64(err_naive_inf))
+    @printf("    Ozaki k=12   max err      = %g\n", Float64(err_ozaki_inf))
+    @printf("    improvement               = %.2fx\n",
+        Float64(err_naive_inf / max(err_ozaki_inf, eps(BigFloat))))
+    @printf("    K·eps·max(|A||B|) bound   = %g\n", Float64(bound_max))
+    @printf("    naive_err / bound         = %.3f\n", Float64(err_naive_inf / bound_max))
+    @printf("    ozaki_err / bound         = %.3g\n", Float64(err_ozaki_inf / bound_max))
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()))
+println("Initial math_mode: ", CUDACore.math_mode(),
+        "   math_precision: ", CUDACore.math_precision())
+println()
+
+for mm in (CUDACore.DEFAULT_MATH, CUDACore.FAST_MATH, CUDACore.PEDANTIC_MATH)
+    CUDACore.math_mode!(mm)
+    println("============================================================")
+    println("math_mode = $mm")
+    println("============================================================")
+    for (M, N, K) in [(64, 64, 64), (128, 128, 128), (256, 256, 256)]
+        run_probe(M, N, K)
+        println()
+    end
+end

--- a/experiments/cutile_probe/probe_schemeII_bench.jl
+++ b/experiments/cutile_probe/probe_schemeII_bench.jl
@@ -1,0 +1,89 @@
+# Where does Scheme II time go, and how does it compare to Scheme I?
+# Scheme II uses 14 GEMMs (vs Scheme I's 43) but a heavier reconstruction
+# (Garner + Int128, here on CPU). Measure GPU-GEMM portion vs CPU-reconstruction
+# vs full, against Scheme I and native FP64.
+
+using CUDACore, CUDA
+using Random, Printf, LinearAlgebra
+
+const MODULI  = Int[256,255,253,251,247,239,233,229,227,223,217,211,199,197,193]
+const gemmI8! = CUDA.CUBLAS.gemmEx!
+const B_BITS = 7; const BASE = 2.0^B_BITS
+
+scale_exp(A; dims) = (mx = maximum(abs.(A); dims=dims);
+    ifelse.(mx .== 0, 0.0, ceil.(log2.(max.(mx, floatmin(Float64)))) .+ 1.0))
+residue_i8(Ap, m) = (r = mod.(Ap, Int64(m)); Int8.(ifelse.(2 .* r .>= m, r .- m, r)))
+
+# Scheme II GPU portion: returns the s residue matrices on CPU.
+function schemeII_gemms(dA, dB, σA, σB; s=14, k=53)
+    M_, N_ = size(dA,1), size(dB,2)
+    Ap = Int64.(round.((2.0^k) .* (dA .* (2.0 .^ (.-σA)))))
+    Bp = Int64.(round.((2.0^k) .* (dB .* (2.0 .^ (.-σB)))))
+    R = Vector{Matrix{Int64}}(undef, s); Cij = CUDA.zeros(Int32, M_, N_)
+    for (t,m) in enumerate(MODULI[1:s])
+        At = residue_i8(Ap, m); Bt = residue_i8(Bp, m)
+        fill!(Cij, Int32(0)); gemmI8!('N','N', Int32(1), At, Bt, Int32(0), Cij)
+        R[t] = Int64.(Array(mod.(Cij, Int32(m))))
+    end
+    return R
+end
+
+function garner_cpu(R, σA, σB; s=14, k=53)
+    mods = MODULI[1:s]
+    minv = [j < t ? invmod(mods[j], mods[t]) : 0 for j in 1:s, t in 1:s]
+    c = Vector{Matrix{Int64}}(undef, s)
+    for t in 1:s
+        ct = copy(R[t])
+        for j in 1:t-1; ct = mod.((ct .- c[j]) .* minv[j,t], mods[t]); end
+        c[t] = ct
+    end
+    Mbig = prod(Int128.(mods)); X = Int128.(c[s])
+    for t in s-1:-1:1; X = X .* Int128(mods[t]) .+ c[t]; end
+    X = ifelse.(X .>= Mbig ÷ 2, X .- Mbig, X)
+    return Float64.(X) .* (2.0^(-2k)) .* σA .* σB
+end
+
+# Scheme I (slice), GPU only, for reference.
+function slices(Ahat, s)
+    D = Vector{CuArray{Int8,2}}(undef, s); t = copy(Ahat)
+    for i in 1:s; t .*= BASE; di = round.(t); D[i] = Int8.(di); t .-= di; end
+    return D
+end
+function schemeI(dA, dB; s=8, T=10)
+    σA = scale_exp(dA; dims=2); σB = scale_exp(dB; dims=1)
+    DA = slices(dA .* (2.0 .^ (.-σA)), s); DB = slices(dB .* (2.0 .^ (.-σB)), s)
+    M_, N_ = size(dA,1), size(dB,2); S = CUDA.zeros(Float64, M_, N_); Cij = CUDA.zeros(Int32, M_, N_)
+    for i in 1:s, j in 1:s
+        i+j <= T || continue
+        fill!(Cij, Int32(0)); gemmI8!('N','N', Int32(1), DA[i], DB[j], Int32(0), Cij)
+        S .+= Float64.(Cij) .* (2.0^(-B_BITS*(i+j)))
+    end
+    return (S .* (2.0 .^ σA)) .* (2.0 .^ σB)
+end
+
+gtime(f;nw=2,nr=6)=(for _ in 1:nw;f();CUDACore.synchronize();end;ts=Float64[];for _ in 1:nr;t0=time_ns();f();CUDACore.synchronize();push!(ts,(time_ns()-t0)/1e9);end;sort(ts)[cld(nr,2)])
+ctime(f;nw=1,nr=3)=(for _ in 1:nw;f();end;ts=Float64[];for _ in 1:nr;t0=time_ns();f();push!(ts,(time_ns()-t0)/1e9);end;sort(ts)[cld(nr,2)])
+
+function run(M, N, K)
+    rng = MersenneTwister(1)
+    A = randn(rng, Float64, M, K); B = randn(rng, Float64, K, N)
+    dA = CuArray(A); dB = CuArray(B)
+    σA = scale_exp(dA; dims=2); σB = scale_exp(dB; dims=1)
+    σAc = Array(2.0 .^ σA); σBc = Array(2.0 .^ σB)
+
+    t_fp64 = gtime(() -> dA * dB)
+    t_I    = gtime(() -> schemeI(dA, dB; s=8, T=10))            # 43 gemms, full
+    t_II_g = gtime(() -> schemeII_gemms(dA, dB, σA, σB; s=14))  # 14 gemms only
+    R = schemeII_gemms(dA, dB, σA, σB; s=14)
+    t_II_r = ctime(() -> garner_cpu(R, σAc, σBc; s=14))         # CPU reconstruction
+    @printf("  %d^3\n", M)
+    @printf("    native FP64 gemm                 %8.2f ms\n", t_fp64*1e3)
+    @printf("    Scheme I  (43 gemms, full)       %8.2f ms\n", t_I*1e3)
+    @printf("    Scheme II GPU GEMMs (14)         %8.2f ms   (%.2fx Scheme I)\n", t_II_g*1e3, t_I/t_II_g)
+    @printf("    Scheme II CPU reconstruction     %8.2f ms\n", t_II_r*1e3)
+    @printf("    Scheme II total (GEMM+recon)     %8.2f ms\n", (t_II_g+t_II_r)*1e3)
+    println()
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()), "\n")
+for s in [1024, 2048]; run(s, s, s); end

--- a/experiments/cutile_probe/probe_schemeII_gpu.jl
+++ b/experiments/cutile_probe/probe_schemeII_gpu.jl
@@ -1,0 +1,130 @@
+# Task 3: Scheme II (CRT) with a FULLY ON-GPU reconstruction.
+#
+# Fixes the three things that made the CPU version ~100x slower than Scheme I:
+#   * residues computed in Float64 (NOT Int64 — consumer GPUs run Int64 ~1/32 rate),
+#   * Garner mixed-radix digits computed on-GPU in Int32,
+#   * the big-integer combine + balanced reduction done in DOUBLE-DOUBLE in a
+#     single CUDA kernel (no Int128, no host transfers).
+#
+# Why double-double suffices: the exact integer X = A'·B' is ~2^114, but the FP64
+# result needs only its top ~53 bits. Reconstructing X·2^-2k = Σ_t c_t·(P_t·2^-2k)
+# in dd (~106 bits) keeps enough; the balanced step (subtract M·2^-2k when
+# X >= M/2) is a dd subtraction whose ~15-bit leading cancellation still leaves
+# ~90 bits — comfortably > 53.
+
+using CUDACore, CUDA
+using Random, Printf, LinearAlgebra
+
+const MODULI  = Int[256,255,253,251,247,239,233,229,227,223,217,211,199,197,193]
+const gemmI8! = CUDA.CUBLAS.gemmEx!
+
+scale_exp(A; dims) = (mx = maximum(abs.(A); dims=dims);
+    ifelse.(mx .== 0, 0.0, ceil.(log2.(max.(mx, floatmin(Float64)))) .+ 1.0))
+
+# Balanced residue of Float64 integer-valued Ap (|Ap|<=2^52) mod m, as INT8.
+function residue_i8_f64(Ap, m)
+    r = Ap .- m .* floor.(Ap ./ m)        # exact: m*floor(...) <= 2^52
+    r = ifelse.(r .< 0, r .+ m, r)
+    r = ifelse.(r .>= m, r .- m, r)        # now r in [0,m)
+    rb = ifelse.(2 .* r .>= m, r .- m, r)  # balanced -> [-m/2, m/2)
+    return Int8.(rb)
+end
+
+# --- double-double combine kernel ---
+@inline function dd_add(ah, al, bh, bl)
+    s = ah + bh; bb = s - ah
+    e = (ah - (s - bb)) + (bh - bb) + al + bl
+    sh = s + e; sl = e - (sh - s)
+    return sh, sl
+end
+
+function combine_kernel!(out, C3, wh, wl, Wh, Wl, Whalf, scaleA, scaleB, M, N, s)
+    idx = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if idx <= M * N
+        r = (idx - 1) % M + 1
+        c = (idx - 1) ÷ M + 1
+        acch = 0.0; accl = 0.0
+        @inbounds for t in 1:s
+            ct = C3[t, r, c]
+            ph = ct * wh[t]
+            pe = fma(ct, wh[t], -ph) + ct * wl[t]
+            acch, accl = dd_add(acch, accl, ph, pe)
+        end
+        if acch >= Whalf                       # X >= M/2  ->  signed: subtract M
+            acch, accl = dd_add(acch, accl, -Wh, -Wl)
+        end
+        @inbounds out[r, c] = (acch + accl) * scaleA[r] * scaleB[c]
+    end
+    return nothing
+end
+
+function schemeII_gpu(A, B; s=14, k=53)
+    M_, N_ = size(A,1), size(B,2)
+    dA = CuArray(A); dB = CuArray(B)
+    σA = scale_exp(dA; dims=2); σB = scale_exp(dB; dims=1)
+    Ap = round.((2.0^k) .* (dA .* (2.0 .^ (.-σA))))    # Float64, |.|<=2^(k-1)
+    Bp = round.((2.0^k) .* (dB .* (2.0 .^ (.-σB))))
+    mods = MODULI[1:s]
+
+    # one exact INT8 GEMM per modulus -> r_t = X mod m_t  (Int32, on GPU)
+    R = Vector{CuArray{Int32,2}}(undef, s)
+    Cij = CUDA.zeros(Int32, M_, N_)
+    for (t,m) in enumerate(mods)
+        At = residue_i8_f64(Ap, m); Bt = residue_i8_f64(Bp, m)
+        fill!(Cij, Int32(0)); gemmI8!('N','N', Int32(1), At, Bt, Int32(0), Cij)
+        R[t] = mod.(Cij, Int32(m))
+    end
+
+    # Garner mixed-radix digits, on GPU in Int32
+    minv = [j < t ? Int32(invmod(mods[j], mods[t])) : Int32(0) for j in 1:s, t in 1:s]
+    cdig = Vector{CuArray{Int32,2}}(undef, s)
+    for t in 1:s
+        ct = copy(R[t]); mt = Int32(mods[t])
+        for j in 1:t-1
+            ct = mod.((ct .- cdig[j]) .* minv[j,t], mt)
+        end
+        cdig[t] = ct
+    end
+
+    # stack digits into (s, M, N) Float64 for the kernel
+    C3 = CUDA.zeros(Float64, s, M_, N_)
+    for t in 1:s
+        @views C3[t, :, :] .= Float64.(cdig[t])
+    end
+
+    # dd weights w_t = P_t * 2^-2k  and  W = M * 2^-2k  (computed in BigFloat)
+    wh = zeros(Float64, s); wl = zeros(Float64, s)
+    Mbig = prod(BigInt.(mods))
+    setprecision(BigFloat, 400) do
+        scale = BigFloat(2)^(-2k)
+        P = BigInt(1)
+        for t in 1:s
+            w = BigFloat(P) * scale
+            wh[t] = Float64(w); wl[t] = Float64(w - wh[t])
+            P *= mods[t]
+        end
+        global Wbf = BigFloat(Mbig) * scale
+    end
+    Wh = Float64(Wbf); Wl = Float64(Wbf - Wh); Whalf = Float64(Wbf / 2)
+
+    out = CUDA.zeros(Float64, M_, N_)
+    sA = vec(2.0 .^ σA); sB = vec(2.0 .^ σB)
+    dwh = CuArray(wh); dwl = CuArray(wl)
+    threads = 256; blocks = cld(M_*N_, threads)
+    @cuda threads=threads blocks=blocks combine_kernel!(out, C3, dwh, dwl,
+        Wh, Wl, Whalf, sA, sB, M_, N_, s)
+    return out
+end
+
+function run(M, N, K; s=14, k=53, seed=1)
+    rng = MersenneTwister(seed)
+    A = randn(rng, Float64, M, K); B = randn(rng, Float64, K, N)
+    P = setprecision(BigFloat, 300) do; BigFloat.(A) * BigFloat.(B); end
+    relerr(C) = Float64(maximum(abs.(BigFloat.(C) .- P)) / maximum(abs.(P)))
+    C = Array(schemeII_gpu(A, B; s=s, k=k)); CUDACore.synchronize()
+    @printf("  %d^3  s=%d k=%d:  relerr = %.3e\n", M, s, k, relerr(C))
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()), "\n")
+for s in (13, 14, 15); run(256, 256, 256; s=s); end
+for s in (14, 15);     run(512, 512, 512; s=s); end

--- a/experiments/cutile_probe/probe_schemeII_gpu_bench.jl
+++ b/experiments/cutile_probe/probe_schemeII_gpu_bench.jl
@@ -1,0 +1,40 @@
+# Benchmark the FULLY ON-GPU Scheme II (14 INT8 GEMMs + GPU Garner + dd kernel)
+# against Scheme I (43 INT8 GEMMs) and native FP64. Does the GEMM-count win now
+# translate to wall-clock, with reconstruction on the GPU?
+
+using CUDACore, CUDA
+using Random, Printf, LinearAlgebra
+include("probe_schemeII_gpu.jl")   # reuse schemeII_gpu + helpers
+
+const BB = 7; const BASEv = 2.0^BB
+function slices_(Ahat, s)
+    D = Vector{CuArray{Int8,2}}(undef, s); t = copy(Ahat)
+    for i in 1:s; t .*= BASEv; di = round.(t); D[i] = Int8.(di); t .-= di; end
+    return D
+end
+function schemeI_(dA, dB; s=8, T=10)
+    σA = scale_exp(dA; dims=2); σB = scale_exp(dB; dims=1)
+    DA = slices_(dA .* (2.0 .^ (.-σA)), s); DB = slices_(dB .* (2.0 .^ (.-σB)), s)
+    M_, N_ = size(dA,1), size(dB,2); S = CUDA.zeros(Float64,M_,N_); Cij = CUDA.zeros(Int32,M_,N_)
+    for i in 1:s, j in 1:s
+        i+j <= T || continue
+        fill!(Cij, Int32(0)); gemmI8!('N','N', Int32(1), DA[i], DB[j], Int32(0), Cij)
+        S .+= Float64.(Cij) .* (2.0^(-BB*(i+j)))
+    end
+    return (S .* (2.0 .^ σA)) .* (2.0 .^ σB)
+end
+gtime(f;nw=2,nr=6)=(for _ in 1:nw;f();CUDACore.synchronize();end;ts=Float64[];for _ in 1:nr;t0=time_ns();f();CUDACore.synchronize();push!(ts,(time_ns()-t0)/1e9);end;sort(ts)[cld(nr,2)])
+
+function bench(M, N, K)
+    rng = MersenneTwister(1)
+    A = randn(rng, Float64, M, K); B = randn(rng, Float64, K, N)
+    dA = CuArray(A); dB = CuArray(B)
+    t_fp64 = gtime(() -> dA * dB)
+    t_I    = gtime(() -> schemeI_(dA, dB; s=8, T=10))
+    t_II   = gtime(() -> schemeII_gpu(A, B; s=14))
+    @printf("  %d^3:  native FP64 %7.2f ms | Scheme I (43) %7.2f ms | Scheme II GPU (14) %7.2f ms  (%.2fx Scheme I, %.2fx FP64)\n",
+        M, t_fp64*1e3, t_I*1e3, t_II*1e3, t_I/t_II, t_fp64/t_II)
+end
+
+println("\n== Scheme II GPU benchmark ==")
+for s in [1024, 2048, 4096]; bench(s, s, s); end

--- a/experiments/cutile_probe/probe_svd_fullgpu.jl
+++ b/experiments/cutile_probe/probe_svd_fullgpu.jl
@@ -1,0 +1,119 @@
+# Prototype: fully on-GPU rigorous SVD.
+#   seed factorization  -> cuSOLVER svd(CuMatrix)            (GPU, approximate, OK: it's only a seed)
+#   certification matmuls-> GPU MMul4 (INT8-Ozaki, rigorous) (GPU)
+#   rigorous O(n^2) bounds (opnorm, Neumann) -> CPU          (setrounding/directed rounding only works on CPU)
+#
+# The big O(n^3) work stays on the card; only the small O(n^2) product matrices
+# are copied back for the rigorous norm bounds.  Compared against the stock CPU
+# `rigorous_svd(A; apply_vbd=false)` for time AND enclosure agreement.
+
+using BallArithmetic, CUDA, LinearAlgebra, Random, Printf
+using BallArithmetic: mid, rad, MiyajimaM1, upper_bound_L2_opnorm,
+                      _compute_svd_bounds, _diagonal_ball_matrix
+import BallArithmetic
+
+to_cpu(B) = BallMatrix(Array(mid(B)), Array(rad(B)))
+gpu_z(c::CuArray) = BallMatrix(c, CUDA.zeros(Float64, size(c)...))
+gpu_z(c) = BallMatrix(CuArray(c), CUDA.zeros(Float64, size(c)...))
+
+# fully-on-GPU certified SVD (MiyajimaM1, no VBD).  Returns (singular_values, normF, normG, timings)
+function rigorous_svd_gpu(A::BallMatrix{Float64,Float64}; method=MiyajimaM1(),
+                          alg=CUDA.CUSOLVER.QRAlgorithm(), seed_on=:gpu)
+    T = Float64
+    local sv, S_cpu, Ug, Vg, Vtg
+    t_seed = if seed_on == :cpu
+        @elapsed begin
+            sv = svd(A.c)                              # CPU LAPACK seed, then upload factors
+            S_cpu = sv.S
+            Ug = gpu_z(CuArray(Matrix(sv.U)))
+            Vg = gpu_z(CuArray(Matrix(sv.V)))
+            Vtg = gpu_z(CuArray(Matrix(sv.Vt)))
+        end
+    else
+        CUDA.@elapsed begin
+            Ac = CuArray(mid(A))
+            sv = svd(Ac; alg=alg)                      # cuSOLVER seed (stays on device)
+            S_cpu = Array(sv.S)
+            Ug = gpu_z(sv.U)
+            Vg = gpu_z(sv.V)
+            Vtg = gpu_z(sv.Vt isa CuArray ? sv.Vt : CuArray(sv.Vt))
+            CUDA.synchronize()
+        end
+    end
+    Σg  = gpu_z(CuArray(Matrix(Diagonal(S_cpu))))
+
+    # GPU MMul4 products (rigorous midpoint+radius); adjoint U' now dispatches to GPU
+    local P1, P2, P3
+    t_prod = CUDA.@elapsed begin
+        P1 = Ug * Σg * Vtg          # ≈ A
+        P2 = Vtg * Vg               # ≈ I (right orthogonality)
+        P3 = Ug' * Ug               # ≈ I (left orthogonality)
+        CUDA.synchronize()
+    end
+
+    # rigorous O(n^2) finish on CPU (directed rounding)
+    t_cpu = @elapsed begin
+        A_cpu = BallMatrix(Array(mid(A)), Array(rad(A)))
+        E = to_cpu(P1) - A_cpu
+        F = to_cpu(P2) - I
+        G = to_cpu(P3) - I
+        normE = upper_bound_L2_opnorm(E)
+        normF = upper_bound_L2_opnorm(F)
+        normG = upper_bound_L2_opnorm(G)
+        if normF >= 1 || normG >= 1
+            error("verification gate failed: normF=$normF normG=$normG")
+        end
+        down, up = _compute_svd_bounds(method, S_cpu, normE, normF, normG, T)
+        mids = (down .+ up) ./ 2
+        radii = setrounding(T, RoundUp) do
+            [max(up[i]-mids[i], mids[i]-down[i]) for i in eachindex(mids)]
+        end
+        global _sv_gpu = [Ball(mids[i], radii[i]) for i in eachindex(mids)]
+        global _nF = normF; global _nG = normG
+    end
+    return _sv_gpu, _nF, _nG, (seed=t_seed, prod=t_prod, cpu=t_cpu)
+end
+
+ct(f; nr=3) = (f(); minimum(@elapsed(f()) for _ in 1:nr))
+gt(f; nr=3) = (f(); CUDA.synchronize(); minimum((CUDA.@elapsed f()) for _ in 1:nr))
+
+function run(n; seed=1)
+    rng = MersenneTwister(seed)
+    A = BallMatrix(randn(rng, n, n) ./ sqrt(n), fill(1e-15, n, n))
+
+    # CPU baseline
+    t_cpu_total = ct(() -> rigorous_svd(A; apply_vbd=false))
+    t_cpu_fact  = ct(() -> svd(A.c))
+    res_cpu = rigorous_svd(A; apply_vbd=false)
+
+    # seed factorization: CPU LAPACK vs cuSOLVER QR vs cuSOLVER Jacobi
+    Ac = CuArray(A.c)
+    t_qr  = gt(() -> svd(Ac; alg=CUDA.CUSOLVER.QRAlgorithm()))
+    t_jac = gt(() -> svd(Ac; alg=CUDA.CUSOLVER.JacobiAlgorithm()))
+    @printf("  seed-only: CPU LAPACK %.3fs | cuSOLVER QR %.3fs | cuSOLVER Jacobi %.3fs\n",
+        t_cpu_fact, t_qr, t_jac)
+
+    # full-GPU (cuSOLVER seed) and hybrid (CPU LAPACK seed + GPU products)
+    sv_f, nFf, nGf, _ = rigorous_svd_gpu(A; seed_on=:gpu)
+    sv_h, nFh, nGh, _ = rigorous_svd_gpu(A; seed_on=:cpu)
+    tf = minimum(begin _,_,_,t = rigorous_svd_gpu(A; seed_on=:gpu); t.seed+t.prod+t.cpu end for _ in 1:3)
+    th = minimum(begin _,_,_,t = rigorous_svd_gpu(A; seed_on=:cpu); t.seed+t.prod+t.cpu end for _ in 1:3)
+    _,_,_,tgf = rigorous_svd_gpu(A; seed_on=:gpu)
+    _,_,_,tgh = rigorous_svd_gpu(A; seed_on=:cpu)
+
+    overlap = all(abs(mid(res_cpu.singular_values[i]) - mid(sv_f[i])) <=
+                  rad(res_cpu.singular_values[i]) + rad(sv_f[i]) + 1e-12 for i in 1:n)
+    maxrad_cpu = maximum(rad.(res_cpu.singular_values))
+
+    @printf("n=%-4d | CPU-all %.3fs | FULL-GPU %.3fs (seed %.3f prod %.3f cpu %.3f) %.1fx | HYBRID %.3fs (seed %.3f prod %.3f cpu %.3f) %.1fx\n",
+        n, t_cpu_total,
+        tf, tgf.seed, tgf.prod, tgf.cpu, t_cpu_total/tf,
+        th, tgh.seed, tgh.prod, tgh.cpu, t_cpu_total/th)
+    @printf("        overlap=%s | σ-radius CPU=%.1e full-gpu=%.1e hybrid=%.1e | gate full(F=%.1e) hybrid(F=%.1e)\n",
+        overlap, maxrad_cpu, maximum(rad.(sv_f)), maximum(rad.(sv_h)), nFf, nFh)
+    flush(stdout)
+end
+
+println("Device: ", CUDA.name(CUDA.device()))
+@printf("CUDAExt loaded: %s\n\n", !isnothing(Base.get_extension(BallArithmetic, :CUDAExt)))
+for n in (512, 1024, 2048); run(n); end

--- a/experiments/cutile_probe/probe_svd_gpu.jl
+++ b/experiments/cutile_probe/probe_svd_gpu.jl
@@ -1,0 +1,76 @@
+# Is RigorousSVDResult faster with the GPU (CUDA INT8) MMul4 dispatch?
+#
+# The rigorous SVD = LAPACK factorization (CPU) + a handful of BallMatrix products
+# to certify it (residual U·Σ·Vt-A, orthogonality Vt·V-I and U'·U-I, residual
+# refinement U·ΔΣ·Vt).  Only those products are O(n^3); the opnorm bounds are O(n^2).
+# We measure:
+#   (1) total CPU rigorous_svd time and how much of it is the certification products,
+#   (2) the same products with GPU-resident BallMatrices (CUDAExt MMul4),
+#   (3) the adjoint gotcha: U' stores an Adjoint{...,CuArray}, NOT a CuArray, so
+#       U'·U does NOT hit the GPU dispatch unless we materialize the adjoint.
+
+using BallArithmetic, CUDA, LinearAlgebra, Random, Printf
+using BallArithmetic: mid, rad
+
+const u64 = eps(Float64)
+
+# materialize so the stored midpoint/radius are plain CuArrays (dispatch fires)
+gpu(A::BallMatrix) = BallMatrix(CuArray(Matrix(mid(A))), CuArray(Matrix(rad(A))))
+
+gt(f; nw=2, nr=5) = (for _ in 1:nw; f(); CUDA.synchronize(); end;
+    ts = Float64[]; for _ in 1:nr; t0 = time_ns(); f(); CUDA.synchronize();
+    push!(ts, (time_ns()-t0)/1e9); end; minimum(ts))
+
+ct(f; nr=3) = (f(); minimum(@elapsed(f()) for _ in 1:nr))
+
+# identity ball matrix on the same backend as X (avoids `- I` scalar indexing on GPU)
+eyelike(X::BallMatrix) = (n = size(X, 2); m = mid(X);
+    BallMatrix(convert(typeof(m), Matrix{eltype(m)}(I, n, n)), zero(m)))
+
+# the certification products of _certify_svd_impl (apply_vbd=false), as a closure
+# over BallMatrices U, Σ, Vt, V, A — works for both CPU and GPU operands.
+# Ut is U' materialized so its storage stays a plain array (GPU dispatch needs that).
+function certify_products(U, Ut, Σ, Vt, V, A, Ivt, Iuu)
+    E = U * Σ * Vt - A
+    F = Vt * V - Ivt
+    G = Ut * U - Iuu
+    R = E + U * Σ * Vt          # stand-in for U*ΔΣ*Vt (same shape/cost)
+    return E, F, G, R
+end
+
+function run(n; seed=1)
+    rng = MersenneTwister(seed)
+    A = BallMatrix(randn(rng, n, n) ./ sqrt(n))
+    # --- CPU reference ---
+    t_fact = ct(() -> svd(A.c))
+    sv = svd(A.c)
+    Ucpu = BallMatrix(sv.U); Vcpu = BallMatrix(sv.V); Vtcpu = BallMatrix(sv.Vt)
+    Σcpu = BallMatrix(Diagonal(sv.S)); Acpu = A
+    Utcpu = BallMatrix(Matrix(sv.U'))     # materialized adjoint (mirror GPU path)
+    Ivt_c = eyelike(Vtcpu * Vcpu); Iuu_c = eyelike(Utcpu * Ucpu)
+    t_prod_cpu = ct(() -> certify_products(Ucpu, Utcpu, Σcpu, Vtcpu, Vcpu, Acpu, Ivt_c, Iuu_c))
+    t_total_cpu = ct(() -> rigorous_svd(A; apply_vbd=false))
+
+    # --- GPU operands (CUDAExt MMul4) ---
+    Ug = gpu(Ucpu); Vg = gpu(Vcpu); Vtg = gpu(Vtcpu); Σg = gpu(Σcpu); Ag = gpu(A)
+    Ugt = BallMatrix(CuArray(Matrix(sv.U')), CUDA.zeros(Float64, size(sv.U,2), size(sv.U,1)))
+    Ivt_g = eyelike(Vtg * Vg); Iuu_g = eyelike(Ugt * Ug)
+    prods_gpu() = certify_products(Ug, Ugt, Σg, Vtg, Vg, Ag, Ivt_g, Iuu_g)
+    t_prod_gpu = gt(prods_gpu)
+
+    # correctness: GPU residual must overlap CPU residual (same midpoint SVD)
+    if n == 512
+        Ec, _, _, _ = certify_products(Ucpu, Utcpu, Σcpu, Vtcpu, Vcpu, Acpu, Ivt_c, Iuu_c)
+        Eg, _, _, _ = prods_gpu()
+        dmid = maximum(abs.(mid(Ec) .- Array(mid(Eg))))
+        @printf("  [check n=512] max |E_cpu - E_gpu| midpoint = %.2e\n", dmid)
+    end
+
+    @printf("n=%-5d | CPU total %.3fs  (factor %.3fs, certify-prods %.3fs = %.0f%%) | GPU prods %.3fs  -> prods speedup %.1fx\n",
+        n, t_total_cpu, t_fact, t_prod_cpu, 100*t_prod_cpu/t_total_cpu, t_prod_gpu, t_prod_cpu/t_prod_gpu)
+    flush(stdout)
+end
+
+println("Device: ", CUDA.name(CUDA.device()))
+@printf("CUDAExt loaded: %s\n\n", !isnothing(Base.get_extension(BallArithmetic, :CUDAExt)))
+for n in (512, 1024, 2048, 4096); run(n); end

--- a/experiments/cutile_probe/probe_tf32_ozaki.jl
+++ b/experiments/cutile_probe/probe_tf32_ozaki.jl
@@ -1,0 +1,100 @@
+# Probe: rigorous TF32-Ozaki GEMM.
+#
+# Three questions:
+#   1. Does FAST_MATH actually dispatch TF32 tensor cores, and at what size?
+#      (Earlier sweep showed no TF32 effect at K<=256.) Signal: naive-TF32
+#      error jumps to ~K*2^-11 relative, far above the FP32-GEMM error.
+#   2. Is the 2-slice Veltkamp split TF32-exact? If A0,A1 are TF32-exact, a
+#      TF32-compute GEMM of them must equal an FP32-compute GEMM bitwise.
+#   3. Does 4-GEMM Ozaki recover FP32-quality accuracy on the TF32 path?
+#
+# Reference is Float64 CPU matmul (accurate enough to separate TF32's ~1e-2
+# error from FP32's ~1e-4), avoiding the BigFloat-at-K=2048 OOM from before.
+
+using CUDACore, CUDA
+using Random, Printf, LinearAlgebra
+
+# IMPORTANT: `A * B` for Float32 CuArrays dispatches to plain cublasSgemm,
+# which ALWAYS computes in full FP32 and ignores math_mode — so TF32 never
+# engages through `*`. To reach the TF32 tensor cores we must call gemmEx!
+# explicitly under FAST_MATH (compute type CUBLAS_COMPUTE_32F_FAST_TF32).
+const gemmEx! = CUDA.CUBLAS.gemmEx!
+
+function gemm_mode(A, B, mode)
+    C = similar(A, size(A, 1), size(B, 2))
+    old = CUDACore.math_mode()
+    CUDACore.math_mode!(mode)
+    try
+        gemmEx!('N', 'N', 1.0f0, A, B, 0.0f0, C)
+    finally
+        CUDACore.math_mode!(old)
+    end
+    return C
+end
+tf32_gemm(A, B) = gemm_mode(A, B, CUDACore.FAST_MATH)      # TF32 tensor cores
+fp32_gemm(A, B) = gemm_mode(A, B, CUDACore.DEFAULT_MATH)    # full FP32
+
+# --- TF32 round via Veltkamp split (s = 13 -> hi has 24-13 = 11 significant
+# bits, exactly TF32-representable). -----------------------------------------
+const VC = Float32(2^13 + 1)
+tf32_hi(A) = (g = VC .* A; g .- (g .- A))
+
+# A = A0 + A1 + eA, with A0, A1 TF32-exact and eA the (FP32-exact) residual.
+function split2(A)
+    A0 = tf32_hi(A)
+    r  = A .- A0
+    A1 = tf32_hi(r)
+    eA = r .- A1
+    return A0, A1, eA
+end
+
+with_mode(f, m) = (old = CUDACore.math_mode(); CUDACore.math_mode!(m);
+                   try f() finally CUDACore.math_mode!(old) end)
+
+function run(M, N, K; seed = 1)
+    rng = MersenneTwister(seed)
+    A = randn(rng, Float32, M, K)
+    B = randn(rng, Float32, K, N)
+    dA = CuArray(A); dB = CuArray(B)
+
+    # References
+    C64 = Float64.(A) * Float64.(B)                       # accurate center
+    relerr(C) = maximum(abs.(Float64.(C) .- C64)) /
+                maximum(abs.(C64))
+
+    # 1. FP32 baseline (full Float32 compute, no tensor cores).
+    C_fp32 = Array(fp32_gemm(dA, dB)); CUDACore.synchronize()
+
+    # 2. Naive TF32 (inputs rounded to TF32 by the compute type).
+    C_tf32 = Array(tf32_gemm(dA, dB)); CUDACore.synchronize()
+
+    # 3. Split + Ozaki on the TF32 tensor cores.
+    A0, A1, _ = split2(dA)
+    B0, B1, _ = split2(dB)
+
+    # TF32-exactness check: gemmEx! of TF32-exact A0,B0 under TF32 compute must
+    # equal the FULL-FP32 compute of the same product (only accumulation
+    # differs, FP32 in both). If equal, the tensor core did not round A0/B0.
+    exact = Array(tf32_gemm(A0, B0)) == Array(fp32_gemm(A0, B0))
+
+    C_oz  = tf32_gemm(A0,B0) .+ tf32_gemm(A0,B1) .+ tf32_gemm(A1,B0) .+ tf32_gemm(A1,B1)
+    C_oz3 = tf32_gemm(A0,B0) .+ tf32_gemm(A0,B1) .+ tf32_gemm(A1,B0)   # drop A1*B1
+    CUDACore.synchronize()
+    C_oz = Array(C_oz); C_oz3 = Array(C_oz3)
+
+    @printf("  M=%d N=%d K=%d\n", M, N, K)
+    @printf("    FP32   relerr = %.3e\n", relerr(C_fp32))
+    @printf("    TF32   relerr = %.3e   (TF32 engaged: %s)\n",
+            relerr(C_tf32), relerr(C_tf32) > 10 * relerr(C_fp32) ? "YES" : "no/maybe")
+    @printf("    A0 TF32-exact under TF32 GEMM: %s\n", exact)
+    @printf("    Ozaki-4 relerr = %.3e\n", relerr(C_oz))
+    @printf("    Ozaki-3 relerr = %.3e   (dropped A1*B1)\n", relerr(C_oz3))
+    println()
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()))
+println("eps(Float32) = ", eps(Float32), "   2^-11 (TF32 unit) = ", 2.0^-11)
+println()
+for (M, N, K) in [(256,256,256), (512,512,512), (1024,1024,1024), (2048,2048,2048)]
+    run(M, N, K)
+end

--- a/experiments/cutile_probe/probe_tf32_rigor.jl
+++ b/experiments/cutile_probe/probe_tf32_rigor.jl
@@ -1,0 +1,99 @@
+# Probe: rigorous TF32-Ozaki ball GEMM — timing + verified enclosure.
+#
+# Center: 4-GEMM Ozaki on TF32 tensor cores (recovers ~FP32 accuracy).
+# Radius: a-priori bound  γ · (|A|·|B|)  with
+#         γ = 2·ε_split + (K+4)·u_f32,   ε_split = 2^-22 (2-slice residual),
+#         u_f32 = 2^-24.  (|A|·|B|) computed in FP32 then inflated to a
+#         rigorous upper bound. This is the same radius an FP32 MMul4 would
+#         give — but the center is produced on the fast TF32 path.
+#
+# Checks:
+#   * enclosure vs BigFloat truth (true rigor) at a modest size,
+#   * timing: 1×FP32 gemm  vs  4×TF32 gemm + recombination (+ radius cost).
+
+using CUDACore, CUDA
+using Random, Printf, LinearAlgebra, Statistics
+
+const gemmEx! = CUDA.CUBLAS.gemmEx!
+function gemm_mode(A, B, mode)
+    C = similar(A, size(A, 1), size(B, 2))
+    old = CUDACore.math_mode(); CUDACore.math_mode!(mode)
+    try; gemmEx!('N','N', 1.0f0, A, B, 0.0f0, C); finally; CUDACore.math_mode!(old); end
+    return C
+end
+tf32_gemm(A, B) = gemm_mode(A, B, CUDACore.FAST_MATH)
+fp32_gemm(A, B) = gemm_mode(A, B, CUDACore.DEFAULT_MATH)
+
+const VC = Float32(2^13 + 1)
+tf32_hi(A) = (g = VC .* A; g .- (g .- A))
+function split2(A)
+    A0 = tf32_hi(A); r = A .- A0; A1 = tf32_hi(r)
+    return A0, A1
+end
+
+# Ozaki center on TF32: A ≈ A0+A1, B ≈ B0+B1, four TF32 GEMMs recombined.
+function ozaki_center(dA, dB)
+    A0, A1 = split2(dA); B0, B1 = split2(dB)
+    return tf32_gemm(A0,B0) .+ tf32_gemm(A0,B1) .+ tf32_gemm(A1,B0) .+ tf32_gemm(A1,B1)
+end
+
+# Rigorous radius γ·(|A|·|B|), with (|A|·|B|) over-estimated.
+function rigor_radius(dA, dB, K)
+    u   = 2.0f0^-24
+    γ   = 2.0f0 * 2.0f0^-22 + Float32(K + 4) * u
+    AB  = fp32_gemm(abs.(dA), abs.(dB))          # ≈ |A|·|B|, round-to-nearest
+    ABhi = AB .* (1.0f0 + Float32(2K) * u)       # inflate to rigorous upper bound
+    return γ .* ABhi
+end
+
+function timeit(f; nwarm=2, nrep=6)
+    for _ in 1:nwarm; f(); CUDACore.synchronize(); end
+    ts = Float64[]
+    for _ in 1:nrep
+        t0 = time_ns(); f(); CUDACore.synchronize()
+        push!(ts, (time_ns()-t0)/1e9)
+    end
+    return sort(ts)[cld(length(ts),2)]
+end
+
+function run(M, N, K; check_rigor=false, seed=1)
+    rng = MersenneTwister(seed)
+    A = randn(rng, Float32, M, K); B = randn(rng, Float32, K, N)
+    dA = CuArray(A); dB = CuArray(B)
+
+    mC = Array(ozaki_center(dA, dB))
+    rC = Array(rigor_radius(dA, dB, K)); CUDACore.synchronize()
+
+    # Timings
+    t_fp32 = timeit(() -> fp32_gemm(dA, dB))
+    t_tf32 = timeit(() -> tf32_gemm(dA, dB))
+    t_oz   = timeit(() -> ozaki_center(dA, dB))
+    t_full = timeit(() -> (ozaki_center(dA, dB); rigor_radius(dA, dB, K)))
+
+    @printf("  M=%d N=%d K=%d\n", M, N, K)
+    @printf("    timing:  FP32 %.2f ms | TF32 %.2f ms | Ozaki-center %.2f ms (%.2fx FP32) | center+radius %.2f ms (%.2fx FP32)\n",
+        t_fp32*1e3, t_tf32*1e3, t_oz*1e3, t_oz/t_fp32, t_full*1e3, t_full/t_fp32)
+    @printf("    radius:  median rel = %.2e   (FP32 K·u ref = %.2e)\n",
+        median(vec(rC) ./ max.(abs.(vec(mC)), 1f-30)), K * 2.0^-24)
+
+    if check_rigor
+        setprecision(BigFloat, 200) do
+            P = BigFloat.(A) * BigFloat.(B)
+            lo = BigFloat.(mC) .- BigFloat.(rC)
+            hi = BigFloat.(mC) .+ BigFloat.(rC)
+            inside = all(lo .<= P .<= hi)
+            margin = minimum(min.(P .- lo, hi .- P))   # >=0 means enclosed
+            ctr_err = maximum(abs.(BigFloat.(mC) .- P))
+            @printf("    ENCLOSURE vs BigFloat: %s   min margin = %.2e   center max err = %.2e\n",
+                inside ? "OK (all entries contained)" : "FAILED", Float64(margin), Float64(ctr_err))
+        end
+    end
+    println()
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()), "\n")
+run(256, 256, 256; check_rigor=true)
+run(512, 512, 512; check_rigor=true)
+for (M,N,K) in [(1024,1024,1024), (2048,2048,2048), (4096,4096,4096)]
+    run(M, N, K)
+end

--- a/experiments/cutile_probe/smoke_test.jl
+++ b/experiments/cutile_probe/smoke_test.jl
@@ -1,0 +1,95 @@
+# Smoke test: load BallArithmetic + cuTile together, exercise the
+# extension via the high-level BallMatrix * BallMatrix interface, and
+# verify the result overlaps the CPU MMul4 result.
+
+using Random, Printf, LinearAlgebra
+using CUDACore
+using BallArithmetic
+using cuTile  # triggers CuTileExt load
+
+const have_ext = Base.get_extension(BallArithmetic, :CuTileExt) !== nothing
+@info "Extension loaded?" have_ext
+
+function compare(::Type{T}, M, N, K) where {T}
+    rng = MersenneTwister(7)
+    mA = rand(rng, T, M, K) .- T(0.5)
+    rA = rand(rng, T, M, K) .* T(1e-3)
+    mB = rand(rng, T, K, N) .- T(0.5)
+    rB = rand(rng, T, K, N) .* T(1e-3)
+
+    A_cpu = BallMatrix(mA, rA)
+    B_cpu = BallMatrix(mB, rB)
+    C_cpu = A_cpu * B_cpu
+
+    A_gpu = BallMatrix(CuArray(mA), CuArray(rA))
+    B_gpu = BallMatrix(CuArray(mB), CuArray(rB))
+    C_gpu = A_gpu * B_gpu
+
+    @assert mid(C_gpu) isa CuArray "GPU dispatch did not happen — mid is $(typeof(mid(C_gpu)))"
+
+    mC_c, rC_c = mid(C_cpu), rad(C_cpu)
+    mC_g, rC_g = Array(mid(C_gpu)), Array(rad(C_gpu))
+
+    cpu_lo, cpu_hi = mC_c .- rC_c, mC_c .+ rC_c
+    gpu_lo, gpu_hi = mC_g .- rC_g, mC_g .+ rC_g
+    overlap_ok = all(max.(gpu_lo, cpu_lo) .<= min.(gpu_hi, cpu_hi))
+
+    mid_diff = maximum(abs.(mC_g .- mC_c))
+    rad_diff = maximum(abs.(rC_g .- rC_c))
+
+    println(@sprintf("  %s M=%d N=%d K=%d: overlap=%s  |Δmid|=%g  |Δrad|=%g",
+        T, M, N, K, overlap_ok, mid_diff, rad_diff))
+    return overlap_ok
+end
+
+function compare_complex(::Type{T}, M, N, K) where {T}
+    rng = MersenneTwister(11)
+    mA = (rand(rng, T, M, K) .- T(0.5)) .+ im .* (rand(rng, T, M, K) .- T(0.5))
+    rA = rand(rng, T, M, K) .* T(1e-3)
+    mB = (rand(rng, T, K, N) .- T(0.5)) .+ im .* (rand(rng, T, K, N) .- T(0.5))
+    rB = rand(rng, T, K, N) .* T(1e-3)
+
+    A_cpu = BallMatrix(mA, rA)
+    B_cpu = BallMatrix(mB, rB)
+    C_cpu = A_cpu * B_cpu
+
+    A_gpu = BallMatrix(CuArray(mA), CuArray(rA))
+    B_gpu = BallMatrix(CuArray(mB), CuArray(rB))
+    C_gpu = A_gpu * B_gpu
+
+    @assert mid(C_gpu) isa CuArray
+
+    mC_c, rC_c = mid(C_cpu), rad(C_cpu)
+    mC_g, rC_g = Array(mid(C_gpu)), Array(rad(C_gpu))
+
+    overlap_ok = all(abs.(mC_g .- mC_c) .<= rC_c .+ rC_g)
+    println(@sprintf("  Complex{%s} M=%d N=%d K=%d: overlap=%s  |Δmid|=%g  |Δrad|=%g",
+        T, M, N, K, overlap_ok,
+        maximum(abs.(mC_g .- mC_c)),
+        maximum(abs.(rC_g .- rC_c))))
+    return overlap_ok
+end
+
+println("Device: ", CUDACore.name(CUDACore.device()))
+println()
+results = Bool[]
+for sz in [(16, 16, 64), (64, 64, 256), (128, 96, 320)]
+    push!(results, compare(Float32, sz...))
+    push!(results, compare(Float64, sz...))
+end
+for sz in [(16, 16, 64), (64, 64, 256)]
+    # NB: complex Float32 BallMatrix * BallMatrix has a pre-existing bug on
+    # CPU (im * BallMatrix{Float32,Float32} constructs a mismatched BallMatrix
+    # type). Skip Float32 here — the GPU kernel itself handles complex via
+    # the same dispatch chain.
+    push!(results, compare_complex(Float64, sz...))
+end
+all_ok = all(results)
+
+if all_ok
+    println("\n✓ All cases overlapped CPU MMul4")
+    exit(0)
+else
+    println("\n✗ At least one case did not overlap")
+    exit(1)
+end

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -1,0 +1,307 @@
+# CUDAExt — GPU rigorous BallMatrix product (MMul4) on NVIDIA INT8 tensor cores.
+#
+# This extension is a Julia / CUDA.jl port of RIKEN R-CCS's GEMMul8
+# (https://github.com/RIKEN-RCCS/GEMMul8, MIT License, © 2025- RIKEN R-CCS),
+# based on the Ozaki Scheme II (Ozaki, Uchino, Imamura, arXiv:2504.08009).
+# It computes the midpoint product via exact INT8-tensor-core GEMMs + a fused
+# CRT reconstruction, and a rigorous radius (also on INT8 tensor cores).
+#
+# Original GEMMul8 license (MIT) — reproduced per its terms:
+#   MIT License. Copyright (c) 2025- RIKEN R-CCS.
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software ... THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY ...
+#   (full text in the upstream repository).
+
+module CUDAExt
+
+using BallArithmetic
+using BallArithmetic: BallMatrix, Ball, mid, rad,
+    SVDMethod, MiyajimaM1, RigorousSVDResult,
+    upper_bound_L2_opnorm, miyajima_vbd
+using CUDA
+using LinearAlgebra
+
+const gemmI8! = CUDA.CUBLAS.gemmEx!          # INT8×INT8 -> INT32 (CUBLAS_COMPUTE_32I)
+# Coprime moduli in [191,256]; M = ∏ grows ~2^(7.97 s). s=16 ⇒ M~2^127.5, which
+# guarantees the exact integer product (M > 2q) for any K up to ~6M at k=53.
+const MODULI = Int[256,255,253,251,247,239,233,229,227,223,217,211,199,197,193,191]
+
+# Storage types accepted by the GPU MMul4.  `adjoint(::BallMatrix)` stores the
+# midpoint/radius as `Adjoint{T,<:CuArray}` (and `transpose` as `Transpose`),
+# which are NOT `<:CuArray`; without matching them the dispatch would silently
+# fall back to the generic CPU `MMul4` (whose `setrounding` is a no-op on the GPU,
+# so that path is not even rigorous).  We match them here and densify below.
+const GPUMat{T} = Union{CUDA.CuArray{T, 2},
+    LinearAlgebra.Adjoint{T, <:CUDA.CuArray{T, 2}},
+    LinearAlgebra.Transpose{T, <:CUDA.CuArray{T, 2}}}
+
+# Materialize to a dense column-major CuArray.  For an Adjoint/Transpose this is a
+# GPU transpose copy — an exact data reshuffle (no rounding), so rigor is preserved.
+# The INT8 residue/reconstruction kernels index linearly and cannot operate on a
+# lazy Adjoint/Transpose wrapper, so densification is required, not just convenient.
+_dense(x::CUDA.CuArray) = x
+_dense(x::Union{LinearAlgebra.Adjoint, LinearAlgebra.Transpose}) = CUDA.CuArray(x)
+
+# cuBLAS's INT8 IMMA `gemmEx` (CUBLAS_COMPUTE_32I on the tensor cores) requires
+# every dimension to be a multiple of 16.  We zero-pad the operands up to the next
+# multiple of 16 and slice the result back: padding the contraction/output
+# dimensions with exact zeros leaves the midpoint product unchanged and only
+# inflates the (already upper) truncation/radius bounds (the bound uses the padded
+# `K`), so rigor is preserved.
+const INT8_TILE = 16
+_next4(n::Int) = cld(n, INT8_TILE) * INT8_TILE
+function _pad4(X::CUDA.CuArray{T, 2}, r::Int, c::Int) where {T}
+    (size(X, 1) == r && size(X, 2) == c) && return X
+    Y = CUDA.zeros(T, r, c)
+    @views Y[1:size(X, 1), 1:size(X, 2)] .= X
+    return Y
+end
+
+scale_exp(A; dims) = (mx = maximum(abs.(A); dims=dims);
+    ifelse.(mx .== 0, 0.0, ceil.(log2.(max.(mx, floatmin(Float64)))) .+ 1.0))
+
+#============================ midpoint (GEMMul8 port) ========================#
+
+# Fused residue extraction (port of GEMMul8 extract_A_lo): read each element of
+# X once, form A' = round(X·2^(k-σ)), write all s balanced-INT8 residues.
+function _residues_kernel!(lo, X, sft, mods, nrows, sz, s, rowwise, k)
+    idx = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if idx <= sz
+        @inbounds begin
+            r = (idx - 1) % nrows + 1
+            c = (idx - 1) ÷ nrows + 1
+            e = rowwise ? sft[r] : sft[c]
+            ap = round(X[idx] * exp2(Float64(k) - e))
+            for i in 1:s
+                m  = mods[i]
+                rr = ap - m * floor(ap / m)
+                rr = rr < 0 ? rr + m : rr
+                rr = rr >= m ? rr - m : rr
+                rb = (2 * rr >= m) ? rr - m : rr
+                lo[idx + (i - 1) * sz] = unsafe_trunc(Int8, rb)
+            end
+        end
+    end
+    return nothing
+end
+
+function _residues!(lo, X, sft, mods_d, nrows, s, k, rowwise)
+    sz = length(X); threads = 256; blocks = cld(sz, threads)
+    @cuda threads=threads blocks=blocks _residues_kernel!(lo, X, sft, mods_d, nrows, sz, s, rowwise, k)
+    return lo
+end
+
+# Fused direct-CRT reconstruction (port of GEMMul8 invscal_device): precomputed
+# double-double weights qPi, error-free accumulation, balanced rint reduction.
+function _invscal_kernel!(C, Cmid, qhi, qlo, Px, Py, invP, scaleA, scaleB, M, sizeC, s)
+    idx = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if idx <= sizeC
+        col = (idx - 1) ÷ M + 1
+        row = (idx - 1) % M + 1
+        chi = 0.0; clo = 0.0
+        @inbounds for i in 1:s
+            a = Float64(Cmid[idx + (i-1)*sizeC])
+            chi = fma(qhi[i], a, chi); clo = fma(qlo[i], a, clo)
+        end
+        quot = round(invP * chi)
+        crt  = fma(Py, quot, fma(Px, quot, chi) + clo)
+        @inbounds C[idx] = crt * scaleA[row] * scaleB[col]
+    end
+    return nothing
+end
+
+# Precompute double-double CRT weights with uniform-absolute (error-free) hi part.
+function _crt_weights(mods)
+    s = length(mods); qhi = zeros(s); qlo = zeros(s)
+    P = prod(BigInt.(mods))
+    rho = sum(div(m, 2) for m in mods)
+    L = (ndigits(P, base=2) - 1) - 52 + ceil(Int, log2(rho))
+    twoL = BigInt(1) << L
+    for i in 1:s
+        Pi = P ÷ mods[i]; qi = invmod(mod(Pi, mods[i]), mods[i]); qPi = qi * Pi
+        n = fld(qPi + (twoL >> 1), twoL)
+        qhi[i] = Float64(n) * 2.0^L; qlo[i] = Float64(qPi - n * twoL)
+    end
+    Px = Py = 0.0
+    setprecision(BigFloat, 400) do
+        Pn = -BigFloat(P); Px = Float64(Pn); Py = Float64(Pn - Px)
+    end
+    return qhi, qlo, Px, Py, Float64(1 / BigFloat(P))
+end
+
+# Exact-CRT midpoint product mA·mB (Float64), via s INT8 GEMMs + fused recon.
+function _midpoint(dmA, dmB, σA, σB; s=16, k=53)
+    M_, N_, K_ = size(dmA,1), size(dmB,2), size(dmA,2); sizeC = M_*N_
+    mods = MODULI[1:s]; mods_d = CuArray(Int32.(mods))
+    Alo = CuArray{Int8}(undef, M_, K_, s); Blo = CuArray{Int8}(undef, K_, N_, s)
+    _residues!(Alo, dmA, vec(σA), mods_d, M_, s, k, true)
+    _residues!(Blo, dmB, vec(σB), mods_d, K_, s, k, false)
+    Cmid = CUDA.zeros(Int32, sizeC, s); Cij = CUDA.zeros(Int32, M_, N_)
+    for (i,m) in enumerate(mods)
+        At = @view Alo[:,:,i]; Bt = @view Blo[:,:,i]
+        fill!(Cij, Int32(0)); gemmI8!('N','N', Int32(1), At, Bt, Int32(0), Cij)
+        @views Cmid[:, i] .= vec(mod.(Cij, Int32(m)))
+    end
+    qhi, qlo, Px, Py, invP = _crt_weights(mods)
+    m_out = CUDA.zeros(Float64, M_, N_)
+    scaleA = vec(2.0 .^ (σA .- k)); scaleB = vec(2.0 .^ (σB .- k))
+    @cuda threads=256 blocks=cld(sizeC,256) _invscal_kernel!(
+        m_out, Cmid, CuArray(qhi), CuArray(qlo), Px, Py, invP, scaleA, scaleB, M_, sizeC, s)
+    return m_out
+end
+
+#============================ radius (INT8 upper bound) =======================#
+
+# Rigorous elementwise UPPER bound on U·V (U,V >= 0) via ONE exact INT8 GEMM
+# with ceil-rounded 7-bit slices.  We only need an upper bound, so the slice
+# truncation is fine — and it runs on the INT8 tensor cores (no rounding control
+# needed, unlike TF32).
+function _int8_upper_product(dU, dV)
+    M_ = size(dU, 1); N_ = size(dV, 2)
+    mxU = maximum(dU; dims=2); mxV = maximum(dV; dims=1)
+    σU = ifelse.(mxU .== 0, 0.0, ceil.(log2.(max.(mxU, floatmin(Float64)))) .+ 1.0)
+    σV = ifelse.(mxV .== 0, 0.0, ceil.(log2.(max.(mxV, floatmin(Float64)))) .+ 1.0)
+    U8 = Int8.(ceil.(dU .* (2.0 .^ (7 .- σU))))
+    V8 = Int8.(ceil.(dV .* (2.0 .^ (7 .- σV))))
+    C  = CUDA.zeros(Int32, M_, N_)
+    gemmI8!('N','N', Int32(1), U8, V8, Int32(0), C)
+    return (Float64.(C) .* (2.0 .^ (σU .- 7)) .* (2.0 .^ (σV .- 7))) .* (1 + 4eps())
+end
+
+#================================ MMul4 dispatch =============================#
+
+# Full rigorous ball product on the GPU.  C = (m, rC) with
+#   m       = exact-CRT INT8 midpoint of mA·mB,
+#   rC      = ρ_trunc (midpoint input-scaling truncation) + rC_in (input radii),
+#             both rigorous upper bounds (INT8 / row-col-sum), rounded up.
+function BallArithmetic.MMul4(
+        A::BallMatrix{T, T, BTA, CMA, RMA},
+        B::BallMatrix{T, T, BTB, CMB, RMB}) where {
+            T <: Float64, BTA, BTB,
+            CMA <: GPUMat{T}, CMB <: GPUMat{T},
+            RMA <: GPUMat{T}, RMB <: GPUMat{T}}
+    k = 53; s = 16
+    u = eps(Float64)
+    # densify (no-op for plain CuArray; exact GPU transpose for Adjoint/Transpose)
+    mA, rA = _dense(mid(A)), _dense(rad(A)); mB, rB = _dense(mid(B)), _dense(rad(B))
+    # pad to multiples of 4 for the INT8 GEMM; remember the true output size
+    M0 = size(mA, 1); N0 = size(mB, 2)
+    Mp = _next4(M0); Kp = _next4(size(mA, 2)); Np = _next4(N0)
+    padded = (Mp, Kp, Np) != (M0, size(mA, 2), N0)
+    if padded
+        mA = _pad4(mA, Mp, Kp); rA = _pad4(rA, Mp, Kp)
+        mB = _pad4(mB, Kp, Np); rB = _pad4(rB, Kp, Np)
+    end
+    K_ = size(mA, 2)
+    σA = scale_exp(mA; dims=2); σB = scale_exp(mB; dims=1)
+
+    m = _midpoint(mA, mB, σA, σB; s=s, k=k)
+
+    # midpoint truncation bound: |δA| <= 2^(σA-k-1) is per-row constant -> no gemm
+    absA = abs.(mA); absB = abs.(mB)
+    rowsumA = sum(absA; dims=2) .* (1 + K_*u)
+    colsumB = sum(absB; dims=1) .* (1 + K_*u)
+    δA = 2.0 .^ (σA .- k .- 1); δB = 2.0 .^ (σB .- k .- 1)
+    ρ_trunc = (δA .* colsumB) .+ (rowsumA .* δB) .+ (Float64(K_) .* (δA .* δB))
+
+    # input-radius propagation: |mA|·rB + rA·(|mB|+rB), via INT8 upper products
+    rC = ρ_trunc .+ (u .* abs.(m))
+    if any(!iszero, rA) || any(!iszero, rB)
+        rC = rC .+ _int8_upper_product(absA, rB) .+ _int8_upper_product(rA, absB .+ rB)
+    end
+    rC = rC .* (1 + 8u)
+    if padded
+        m  = CUDA.CuArray(@view m[1:M0, 1:N0])
+        rC = CUDA.CuArray(@view rC[1:M0, 1:N0])
+    end
+    return BallMatrix(m, rC)
+end
+
+#============================ GPU rigorous SVD ===============================#
+
+# Wrap a host/device matrix as a zero-radius GPU ball matrix.
+_gpu_ball(c::CUDA.CuArray) = BallMatrix(c, CUDA.zeros(Float64, size(c)...))
+_gpu_ball(c) = BallMatrix(CUDA.CuArray(c), CUDA.zeros(Float64, size(c)...))
+# Build a GPU ball matrix from explicit (midpoint, radius) host/device matrices.
+_gpu_ball(m, r) = BallMatrix(CUDA.CuArray(m), CUDA.CuArray(r))
+# Copy a GPU ball matrix back to the CPU.
+_to_cpu(B::BallMatrix) = BallMatrix(Array(mid(B)), Array(rad(B)))
+
+# GPU-accelerated rigorous SVD.  The `O(n³)` certification products run on the
+# GPU `MMul4`; the `O(n²)` rigorous finish (norm bounds, Neumann gate,
+# singular-value enclosures, optional VBD) runs on the CPU with directed
+# rounding, exactly as in the CPU `rigorous_svd`.  See `rigorous_svd_gpu`.
+function BallArithmetic.rigorous_svd_gpu(A::BallMatrix{Float64, Float64};
+        method::SVDMethod = MiyajimaM1(), apply_vbd::Bool = true,
+        seed_on::Symbol = :cpu, alg = CUDA.CUSOLVER.QRAlgorithm())
+    T = Float64
+    mA = mid(A)
+
+    # --- seed factorisation (approximate; only a starting point) -----------
+    Smid, Uc, Vc, Vtc = if seed_on == :gpu
+        Fg = svd(CUDA.CuArray(mA); alg = alg)          # cuSOLVER, stays on device
+        (Array(Fg.S), Fg.U, Fg.V, Fg.Vt isa CUDA.CuArray ? Fg.Vt : CUDA.CuArray(Fg.Vt))
+    elseif seed_on == :cpu
+        F = svd(mA)                                    # CPU LAPACK, then upload
+        (F.S, Matrix(F.U), Matrix(F.V), Matrix(F.Vt))
+    else
+        throw(ArgumentError("seed_on must be :cpu or :gpu, got $(seed_on)"))
+    end
+
+    Ug  = _gpu_ball(Uc)
+    Vg  = _gpu_ball(Vc)
+    Vtg = _gpu_ball(Vtc)
+    Σg  = _gpu_ball(Matrix(Diagonal(Smid)))
+
+    # --- O(n³) certification products on the GPU (rigorous MMul4) ----------
+    P1 = Ug * Σg * Vtg        # ≈ A
+    P2 = Vtg * Vg             # ≈ I  (right orthogonality)
+    P3 = Ug' * Ug             # ≈ I  (left orthogonality)
+    CUDA.synchronize()
+
+    # --- O(n²) rigorous finish on the CPU (directed rounding) --------------
+    E = _to_cpu(P1) - A
+    Fdef = _to_cpu(P2) - I
+    Gdef = _to_cpu(P3) - I
+    normE = upper_bound_L2_opnorm(E)
+    normF = upper_bound_L2_opnorm(Fdef)
+    normG = upper_bound_L2_opnorm(Gdef)
+
+    # CPU ball factors for the returned result.
+    U  = BallMatrix(Array(Uc))
+    V  = BallMatrix(Array(Vc))
+
+    # Neumann gate: ‖F‖ < 1 and ‖G‖ < 1 are required for the bounds.
+    if normF >= 1 || normG >= 1
+        n_sv = length(Smid)
+        singular_values = [Ball(Smid[i], T(Inf)) for i in 1:n_sv]
+        Σ = BallArithmetic._diagonal_ball_matrix(singular_values)
+        @warn "GPU SVD verification failed: ‖V'V - I‖ = $normF, ‖U'U - I‖ = $normG (both must be < 1)"
+        return RigorousSVDResult(U, singular_values, Σ, V, E,
+            T(Inf), normF, normG, nothing)
+    end
+
+    down, up = BallArithmetic._compute_svd_bounds(method, Smid, normE, normF, normG, T)
+    mids = (down .+ up) ./ 2
+    radii = setrounding(T, RoundUp) do
+        [max(up[i] - mids[i], mids[i] - down[i]) for i in eachindex(mids)]
+    end
+    singular_values = [Ball(mids[i], radii[i]) for i in eachindex(mids)]
+    Σ = BallArithmetic._diagonal_ball_matrix(singular_values)
+
+    # Residual `U Σ Vᵀ - A` reusing the midpoint residual `E`, accounting only
+    # for the widening from `Σ_mid` to the ball diagonal `Σ`.  The `O(n³)`
+    # correction product `U ΔΣ Vᵀ` is formed on the GPU.
+    ΔΣg = _gpu_ball(Matrix(Diagonal(mids .- Smid)), Matrix(Diagonal(radii)))
+    corr = _to_cpu(Ug * ΔΣg * Vtg)
+    CUDA.synchronize()
+    residual = E + corr
+    residual_norm = upper_bound_L2_opnorm(residual)
+
+    vbd = apply_vbd ? miyajima_vbd(adjoint(Σ) * Σ; hermitian = true) : nothing
+
+    return RigorousSVDResult(U, singular_values, Σ, V, residual,
+        residual_norm, normF, normG, vbd)
+end
+
+end # module

--- a/ext/CuTileExt.jl
+++ b/ext/CuTileExt.jl
@@ -1,0 +1,86 @@
+module CuTileExt
+
+using BallArithmetic
+using cuTile: cuTile
+import cuTile as ct
+using CUDACore
+
+# One thread block computes one (tm × tn) output tile of the BallMatrix
+# product MMul4(A, B) using cuTile's elementwise tile ops. The tile-level
+# `mma` intrinsic (which backs `muladd(tile, tile, tile)`) silently
+# ignores @fpmode because tensor-core MMA is hardware-fixed to round-to-
+# nearest-even, so this kernel deliberately accumulates as outer-products
+# of (tm × 1) × (1 × tn) tiles under @fpmode, which lowers to addf/mulf
+# intrinsics that *do* honor the rounding attribute.
+function _mmul4_kernel!(mC::ct.TileArray{T,2}, rC::ct.TileArray{T,2},
+                       mA::ct.TileArray{T,2}, rA::ct.TileArray{T,2},
+                       mB::ct.TileArray{T,2}, rB::ct.TileArray{T,2},
+                       tm::Int, tn::Int) where {T}
+    bid_m = ct.bid(1)
+    bid_n = ct.bid(2)
+    K = size(mA, 2)
+
+    acc_up = zeros(T, tm, tn)
+    acc_r  = zeros(T, tm, tn)
+
+    ct.@fpmode rounding_mode=ct.Rounding.PosInf flush_to_zero=false begin
+        for k in Int32(1):Int32(K)
+            mA_col = ct.load(mA; index=(bid_m, k), shape=(tm, 1),
+                             padding_mode=ct.PaddingMode.Zero)
+            mB_row = ct.load(mB; index=(k, bid_n), shape=(1, tn),
+                             padding_mode=ct.PaddingMode.Zero)
+            rA_col = ct.load(rA; index=(bid_m, k), shape=(tm, 1),
+                             padding_mode=ct.PaddingMode.Zero)
+            rB_row = ct.load(rB; index=(k, bid_n), shape=(1, tn),
+                             padding_mode=ct.PaddingMode.Zero)
+
+            absA = cuTile.Intrinsics.absf(mA_col)
+            absB = cuTile.Intrinsics.absf(mB_row)
+
+            acc_up = acc_up + mA_col * mB_row
+            acc_r  = acc_r  + absA * rB_row + rA_col * (absB + rB_row)
+        end
+        acc_up = acc_up + acc_r        # C2
+    end
+
+    acc_dn = zeros(T, tm, tn)
+    ct.@fpmode rounding_mode=ct.Rounding.NegInf flush_to_zero=false begin
+        for k in Int32(1):Int32(K)
+            mA_col = ct.load(mA; index=(bid_m, k), shape=(tm, 1),
+                             padding_mode=ct.PaddingMode.Zero)
+            mB_row = ct.load(mB; index=(k, bid_n), shape=(1, tn),
+                             padding_mode=ct.PaddingMode.Zero)
+            acc_dn = acc_dn + mA_col * mB_row
+        end
+        acc_dn = acc_dn - acc_r        # C1
+    end
+
+    ct.@fpmode rounding_mode=ct.Rounding.PosInf flush_to_zero=false begin
+        mid_tile = (acc_dn + acc_up) * T(0.5)
+        rad_tile = mid_tile - acc_dn
+        ct.store(mC; index=(bid_m, bid_n), tile=mid_tile)
+        ct.store(rC; index=(bid_m, bid_n), tile=rad_tile)
+    end
+    return nothing
+end
+
+# NOTE: this cuTile outer-product kernel is kept for reference (it is the only
+# directed-rounding GPU path — see ext/RIGOROUS_GPU_GEMM.md, Route 1). The
+# production GPU `MMul4` dispatch now lives in `CUDAExt.jl` (INT8 Ozaki-II port,
+# much faster). To avoid a method clash with that overload on Float64 `CuArray`
+# ball matrices, `CuTileExt` no longer registers a `MMul4` method; call the
+# kernel directly via `_mmul4_kernel!` if you want to exercise this path.
+function _cutile_mmul4(A::BallMatrix{T, T}, B::BallMatrix{T, T}) where {T <: Union{Float32, Float64}}
+    mA, rA = mid(A), rad(A)
+    mB, rB = mid(B), rad(B)
+    M_ = size(mA, 1); N_ = size(mB, 2)
+    mC = CUDACore.CuArray{T}(undef, M_, N_)
+    rC = CUDACore.CuArray{T}(undef, M_, N_)
+    tm, tn = 16, 16
+    grid = (cld(M_, tm), cld(N_, tn))
+    @cuda backend=cuTile blocks=grid _mmul4_kernel!(mC, rC, mA, rA, mB, rB,
+        ct.Constant(tm), ct.Constant(tn))
+    return BallMatrix(mC, rC)
+end
+
+end # module

--- a/ext/RIGOROUS_GPU_GEMM.md
+++ b/ext/RIGOROUS_GPU_GEMM.md
@@ -1,0 +1,510 @@
+# Rigorous GPU GEMM for BallArithmetic.jl — experiment notes
+
+Goal: compute `MMul4` (the rigorous ball-arithmetic matrix product) on NVIDIA
+GPUs, exploring several routes — a directed-rounding cuTile kernel, a
+TF32-tensor-core "Ozaki" scheme via cuBLAS, and INT8 Ozaki-Scheme-I/II. All
+experiments below were run on an **RTX 4060 Ti** (Ada, AD106, consumer); the
+scripts live in `experiments/cutile_probe/`.
+
+> **Attribution.** `experiments/cutile_probe/gemmul8_port.jl` is a **Julia /
+> CUDA.jl port of RIKEN R-CCS's [GEMMul8](https://github.com/RIKEN-RCCS/GEMMul8)**
+> (Ozaki Scheme II, MIT License, © 2025- RIKEN R-CCS). The MIT notice is
+> reproduced in that file's header. See the References section.
+
+`MMul4` recap: `C2 = mA·mB + rC` (RoundUp), `C1 = mA·mB − rC` (RoundDown),
+`rC = |mA|·rB + rA·(|mB|+rB)` (RoundUp), `mC = (C1+C2)/2`, `rC = mC − C1`. The
+result is a ball matrix guaranteed to contain the true product.
+
+---
+
+## Route 1 — directed-rounding cuTile kernel (`CuTileExt.jl`)
+
+cuTile's `@fpmode rounding_mode=…` lets a kernel pick the FP rounding direction,
+which is exactly what directed-rounding ball arithmetic needs.
+
+**Finding (blocker for tensor cores):** `@fpmode` is honored by the *elementwise*
+tile ops (`addf`, `mulf`, `subf`, …) but **silently ignored** by the tile-level
+`mma` / `muladd(tile,tile,tile)` matmul — tensor-core MMA is hardware-fixed to
+round-to-nearest-even, and `encode_MmaFOp!` never receives the fpmode attribute.
+Running the same tile matmul under `PosInf`, `NegInf`, `NearestEven` gives
+**bitwise-identical** output (`probe.jl`).
+
+→ Filed upstream as **JuliaGPU/cuTile.jl issue #229** (ask: docs / an IRError on
+misuse / eventual plumbing). Draft in `experiments/cutile_probe/issue_draft.md`.
+
+**Workaround that works:** express the matmul as **outer-product accumulation**
+of `(tm×1)×(1×tn)` tiles inside the `@fpmode` scope — these lower to `mulf`/`addf`
+which *do* honor the mode. This is what `CuTileExt.jl` implements: three
+`@fpmode` scopes (RoundUp for `C2`/`rC`, RoundDown for `C1`, RoundUp for the
+final mid/rad). Validated rigorously — every output ball overlaps the CPU
+`MMul4` (`probe_mmul4.jl`, `smoke_test.jl`, 8 cases). It is correct, but bypasses
+tensor cores.
+
+### Float64 benchmark — GPU (CuTileExt) vs CPU (multithreaded OpenBLAS)
+
+`bench_mmul4.jl`, median of 5 runs, overlap-verified each size:
+
+| Size | CPU | GPU | GPU vs CPU |
+|------|-----|-----|-----------|
+| 128³ | 0.34 ms | 0.31 ms | 1.09× (tie, overhead-bound) |
+| 256³ | 1.36 ms | 2.19 ms | 0.62× |
+| 512³ | 11.2 ms | 16.6 ms | 0.67× |
+| 1024³ | 55.5 ms | 118.9 ms | 0.47× |
+| 2048³ | 431 ms | 934 ms | 0.46× |
+
+CPU throughput climbs to ~80 GF/s as threading amortizes; the GPU plateaus at
+~37 GF/s (FP64 compute-bound). **Float64 rigorous GEMM is a net loss on consumer
+NVIDIA hardware** — two compounding reasons:
+
+1. No tensor cores (forced by the `@fpmode`/`mma` limitation above).
+2. Consumer Ada FP64 runs at 1/64 of FP32 and has **no** FP64 tensor cores.
+
+This is hardware-specific: FP64 tensor cores exist only on the datacenter dies
+(A100/GA100, H100/GH100, Blackwell). On an A100 the *same* outer-product kernel
+would be limited by ~9.7 TF of FP64 (½ the FP32 rate) instead of the consumer
+1/64 cap — comfortably above the CPU baseline. Note: the A40 on toeplitz is
+GA102-based and has the consumer FP64 penalty, so it would **not** help Float64.
+
+---
+
+## Route 2 — TF32-Ozaki ball GEMM via cuBLAS
+
+Idea: TF32 tensor cores round FP32 inputs to an 11-bit mantissa (their ~5e-4
+error) but **accumulate in FP32**. Pre-split each input into TF32-exact slices
+so the tensor core can't round them; then every per-element product (11×11 = 22
+bits) is exact in the FP32 accumulator, and only the K-fold sum rounds —
+recovering ~FP32 accuracy at tensor-core throughput. No custom kernel needed:
+it's just cuBLAS GEMMs.
+
+```
+A = A0 + A1 + eA   (Veltkamp split, s=13 → A0,A1 each 11 significant bits = TF32-exact)
+A·B ≈ A0·B0 + A0·B1 + A1·B0 + A1·B1     (four TF32 GEMMs, eA·… dropped & bounded)
+```
+
+### Gotcha: `*` never uses TF32
+
+`A * B` for `Float32` CuArrays dispatches to plain `cublasSgemm`, which **always**
+computes in full FP32 and ignores `math_mode`. TF32 is only reachable by calling
+`CUDA.CUBLAS.gemmEx!('N','N', 1f0, A, B, 0f0, C)` under
+`CUDACore.math_mode!(FAST_MATH)` (→ compute type `CUBLAS_COMPUTE_32F_FAST_TF32`,
+with `math_precision() == :TensorFloat32`). This explains an earlier "TF32 not
+engaging" red herring: through `*`, FP32 and "TF32" are bitwise identical at all
+sizes. (`probe_tf32_ozaki.jl`.)
+
+### Accuracy — Ozaki recovers near-FP32 on TF32
+
+Relative error vs a Float64 reference (`probe_tf32_ozaki.jl`):
+
+| Size | FP32 | naive TF32 | Ozaki-4 | Ozaki-3 (drop A1·B1) |
+|------|------|-----------|---------|----------------------|
+| 256³ | 2.2e-7 | 3.0e-4 | 1.1e-6 | 1.1e-6 |
+| 512³ | 5.4e-7 | 3.2e-4 | 2.5e-6 | 2.5e-6 |
+| 1024³ | 2.7e-7 | 2.6e-4 | 4.0e-6 | 4.0e-6 |
+| 2048³ | 4.1e-7 | 3.2e-4 | 8.6e-6 | 8.6e-6 |
+
+Ozaki improves the TF32 center by **30–300×** (3e-4 → ~1e-6), to within ~20× of
+full FP32. The `A1·B1` term is negligible (Ozaki-3 == Ozaki-4) → **3 GEMMs
+suffice**. The error grows like √K (the FP32 accumulation of the split residual),
+as expected.
+
+### Rigor — verified enclosure
+
+Radius `γ·(|A|·|B|)` with `γ = 2·2⁻²² + (K+4)·2⁻²⁴`, `(|A|·|B|)` computed in FP32
+and inflated to a rigorous upper bound. Checked against a 200-bit **BigFloat**
+truth (`probe_tf32_rigor.jl`):
+
+| Size | enclosure | center max err | radius (median rel) |
+|------|-----------|----------------|---------------------|
+| 256³ | **OK — all entries contained** | 7.8e-5 | 2.4e-4 |
+| 512³ | **OK — all entries contained** | 2.7e-4 | 6.7e-4 |
+
+The radius is dominated by the `|A|·|B| / |A·B|` amplification (≈√K for `randn`
+inputs), which is intrinsic to *any* ball/interval GEMM — an FP32 `MMul4` carries
+the same factor. So the balls are about as tight as an FP32 `MMul4`, with the
+center produced on the TF32 path.
+
+### Timing — net loss on the 4060 Ti
+
+`probe_tf32_rigor.jl`, median of 6 runs:
+
+| Size | FP32 gemm | TF32 gemm | Ozaki center (3–4 gemm) | center + radius |
+|------|-----------|-----------|-------------------------|-----------------|
+| 1024³ | 0.21 ms | 0.14 ms | 0.81 ms (3.8× FP32) | 1.11 ms (5.2× FP32) |
+| 2048³ | 1.37 ms | 0.92 ms | 5.27 ms (3.8× FP32) | 7.03 ms (5.1× FP32) |
+| 4096³ | 10.5 ms | 7.0 ms | 34.4 ms (3.3× FP32) | 46.7 ms (4.5× FP32) |
+
+On this card a single TF32 gemm is only **~1.5× faster** than FP32, so 3–4 TF32
+gemms cost **~3.3–3.8×** a single FP32 gemm — a clear loss. The whole premise
+needs TF32 ≫ FP32 to pay off, and that ratio is small on consumer Ada.
+
+---
+
+## Route 3 — INT8 tensor cores via Ozaki Scheme II (recommended direction)
+
+**Reference:** K. Ozaki, Y. Uchino, T. Imamura, *"Ozaki Scheme II: A GEMM-oriented
+emulation of floating-point matrix multiplication using an integer modular
+technique"*, arXiv:2504.08009 (2025).
+
+This route sidesteps **both** blockers above. The key property:
+**INT8×INT8 → INT32 tensor-core products are EXACT** — integer MMA does no
+rounding at all (provided the accumulation stays within INT32 range). So:
+
+* Route 1's blocker (tensor-core MMA ignores `@fpmode`) is irrelevant — there is
+  no rounding to direct.
+* Route 2's blocker (TF32 round-to-nearest, only ~1.5× FP32 on consumer Ada) is
+  gone — exact INT8 is *much* faster than FP32 on consumer cards.
+
+**Method.** Scale FP matrices to integers with exact power-of-two diagonal
+scaling `C = AB = D⁻¹(DA)(BE)E⁻¹`; reduce modulo a set of coprime moduli
+`mᵢ ∈ [191,256]`; compute one **exact** INT8 GEMM per modulus (`cublasGemmEx`,
+INT8→INT32, with `m,n,k` multiples of 4); reconstruct the exact integer product
+via the **Chinese Remainder Theorem**; scale back. The *only* error is the
+deliberate input truncation, controlled by the number of moduli `s` (k bits,
+`k = ⌊log₂(M/2q)/2⌋`). FP64-equivalent accuracy needs `s ≈ 14–16` GEMMs
+(vs ~28–35 for the original FP-splitting Ozaki Scheme I).
+
+**Why this is the right fit for ball arithmetic.** The integer products are
+exact and the CRT reconstruction is exact, so the computed center is the *exact*
+product of the truncated inputs. The radius only has to cover the input
+truncation `A = A' + ΔA` (a known, a-priori bound) — there is **no accumulation
+rounding to bound**. Adding moduli shrinks the radius arbitrarily. This is
+strictly tighter and cleaner than the TF32-Ozaki radius of Route 2.
+
+**Why it should win even on consumer hardware.** Consumer cards have fast INT8
+tensor cores but crippled FP64. Paper results:
+
+| Hardware | FP64-equiv via INT8-Ozaki | native FP64 | speedup |
+|----------|---------------------------|-------------|---------|
+| RTX 4090 (consumer Ada) | 7.4–9.8 TFLOPS (s=14–15) | 1.29 TFLOPS | ~6–7× |
+| GH200 | 56.6–80.2 TFLOPS (s=14) | 61.9 TFLOPS (FP64 TC) | ~comparable |
+
+The RTX 4090 is the same consumer-Ada situation as the **RTX 4060 Ti** here, so
+INT8-Ozaki is the route most likely to make rigorous **Float64** GEMM a *win* on
+this card — beating both native GPU FP64 and plausibly the multithreaded CPU.
+
+The INT8 GEMM primitive is reached through the same path we use elsewhere:
+`CUDA.CUBLAS.gemmEx!('N','N', Int32(1), A_int8, B_int8, Int32(0), C_int32)`
+(sig `(Int8,Int32)` → `CUBLAS_COMPUTE_32I`, requires `m,n,k % 4 == 0`). Verified
+**bit-exact** vs an integer CPU reference.
+
+### Prototype results (slice-based Scheme I, this repo)
+
+Implemented as a slice split (base `2^7`, per-row/col power-of-two scaling),
+exact INT8 GEMMs for pairs `i+j ≤ T`, FP64 recombination. Scripts:
+`probe_int8_ozaki.jl` (accuracy), `probe_int8_bench.jl` (timing),
+`probe_int8_rigor.jl` (enclosure), `probe_int8_streams.jl` (breakdown).
+
+**Accuracy** (relerr vs 250-bit BigFloat, randn inputs) — tunable via `T`:
+
+| s, T | #GEMMs | 256³ | 512³ |
+|------|--------|------|------|
+| native FP64 gemm | 1 | 1.1e-15 | 1.4e-15 |
+| 8, 8 | 28 | 4.1e-14 | 5.4e-14 |
+| 8, 10 | 43 | **4.6e-16** | **5.4e-16** |
+| 8, 16 | 64 | 4.6e-16 | 5.4e-16 |
+
+→ 43 GEMMs **match/beat native FP64**; full reconstruction at 64.
+
+**Timing vs native FP64 gemm (RTX 4060 Ti)** — INT8-Ozaki *wins at scale*:
+
+| Size | native FP64 | single INT8 | INT8/FP64 per-gemm | Ozaki T=8 (28) | Ozaki T=10 (43) |
+|------|-------------|-------------|--------------------|----------------|------------------|
+| 512³ | 1.0 ms | 0.04 ms | 26× | 0.48× | 0.38× |
+| 1024³ | 7.6 ms | 0.09 ms | 82× | 0.97× | 0.82× |
+| 2048³ | 56 ms | 0.47 ms | 120× | **1.13×** | 0.92× |
+| 4096³ | 413 ms | 3.3 ms | 126× | **1.65×** | **1.28×** |
+
+A single INT8 GEMM is up to **126× faster** than FP64; crossover ~1–2k. (More
+modest than the paper's 6–7× because this is Scheme I with 28–43 GEMMs, not
+Scheme II's ~16, and the FP64 recombination is unoptimized — see below.)
+
+**Timing vs the CPU** (`probe_int8_vs_cpu.jl`, 6-thread OpenBLAS). NOTE: this
+compares the GPU **midpoint** product against the CPU **full `MMul4`** (mid +
+radius) — *not* apples-to-apples; it overstates the GPU win. For the corrected
+full-`MMul4`-vs-full-`MMul4` figure (~6–8×) see the GEMMul8-port section. With
+that caveat, the midpoint-vs-CPU-MMul4 table:
+
+| Size | CPU FP64 gemm (non-rig.) | CPU MMul4 (rig.) | GPU INT8-Ozaki midpoint (rig.) | ratio |
+|------|--------------------------|-------------------|--------------------------------|-------|
+| 1024³ | 8.0 ms | 61 ms | 9.4 ms | 6.6× |
+| 2048³ | 57 ms | 661 ms | 61 ms | 10.8× |
+| 4096³ | 452 ms | 2926 ms | 326 ms | 9.0× |
+
+The CPU `MMul4` is itself ~8× a plain gemm (directed-rounding GEMMs through the
+slow ConsistentFPCSR BLAS). The GPU midpoint is also ≥ the CPU's *non-rigorous*
+gemm (1.0× → 1.8×). This reverses Route 1, where CuTileExt Float64 *lost* to the
+CPU by ~2×. (Again: the full GPU `MMul4` adds a cheap radius → ~6–8× overall.)
+
+**Rigor** — verified enclosure of the exact `A·B` vs 300-bit BigFloat:
+**all entries contained** at 256³/512³. Two radius bounds:
+- *Loose* (`probe_int8_rigor.jl`): `loA·fullB + fullA·loB`, ~10⁶× the true error
+  (over-counts non-dropped pairs `i+j ≤ T`).
+- *Tight* (`probe_int8_rigor_tight.jl`, **done**): the per-`i` tail-sum form
+  `Σ_i x_i·Ytail_{T-i}` in FP32 (≤`s` extra GEMMs) + a rigorous recombination
+  bound (`Σ|terms|·u`) + residual bound (row/col sums, no GEMM). At T=10 this
+  gives **radius 1.1e-14 rel, only ~20–24× the true center error** — tighter than
+  a native FP64 `MMul4` (~1e-13), and at the `√K` cancellation floor that any
+  rigorous ball GEMM pays.
+
+| Size | T | radius (rel) | radius/err | gemms |
+|------|---|--------------|------------|-------|
+| 256³ | 8 | 6.8e-13 | 16.6× | 28 INT8 + 8 FP32 |
+| 256³ | 10 | 1.1e-14 | 23.8× | 43 INT8 + 6 FP32 |
+| 512³ | 10 | 1.1e-14 | 20.0× | 43 INT8 + 6 FP32 |
+
+**Bottleneck / parallelism** (`probe_int8_streams.jl`, 4096³, 43 GEMMs):
+
+| Stage | Time |
+|-------|------|
+| split (FP64→INT8) | 93 ms |
+| 43 GEMMs sequential | 150 ms |
+| 43 GEMMs, 4 / 8 streams | 150 / 152 ms (**no speedup**) |
+| FP64 recombination only | 60 ms |
+| full (interleaved) | 209 ms |
+
+Key findings: (1) **spreading GEMMs over streams does nothing** — one INT8 GEMM
+already saturates the tensor cores at this size, so concurrent streams just
+time-slice. (2) The FP64 **split + recombine (153 ms) rivals the GEMMs (150 ms)**
+and the interleaved pipeline does *not* overlap them (209 ≈ 150 + 60). The real
+wins are: overlap the memory-bound recombine with the next tensor-core GEMM
+(2-stream producer/consumer); **group recombination by `i+j`** (sum Int32 in
+integer, one FP64 convert+scale per diagonal → ~15 reduces, not 43); and move to
+**Scheme II** (CRT, ~16 GEMMs) to cut both GEMM and recombination cost.
+
+### Scheme II (CRT) — implemented & verified, but reconstruction-bound
+
+The CRT variant (arXiv:2504.08009) replaces the `~T²/2` slice-pair GEMMs with
+**one GEMM per modulus**: scale to integer `A',B'`; for each of `s` coprime
+moduli `mₜ∈[191,256]` reduce to balanced INT8 residues, GEMM exactly to INT32,
+take `mod mₜ` → `X mod mₜ`; reconstruct the exact integer `X = A'·B'` by CRT
+(Garner), then `C = 2^(σA+σB−2k)·X`. (`probe_int8_schemeII.jl`,
+`probe_schemeII_bench.jl`.)
+
+**Correctness — confirmed.** Sharp threshold at `M = Πmₜ > 2q`:
+
+| s, k | #GEMMs | 256³ | 512³ |
+|------|--------|------|------|
+| 12, 53 | 12 | 1.0e0 (fail, M<2q) | 1.0e0 (fail) |
+| 13, 53 | 13 | 9.8e-1 (fail) | 1.0e0 (fail) |
+| **14, 53** | **14** | **4.7e-16** | **6.0e-16** |
+| 15, 53 | 15 | 4.7e-16 | 6.0e-16 |
+
+→ Full FP64 with **14 GEMMs vs Scheme I's 43** — the promised 3× GEMM cut.
+
+**Performance — a net loss as implemented (~100× slower than Scheme I):**
+
+| Stage (1024³) | Time | (2048³) |
+|---------------|------|---------|
+| Scheme I (43 gemms, full) | 9.4 ms | 62 ms |
+| Scheme II — GPU GEMM portion (14) | 235 ms | 498 ms |
+| Scheme II — CPU Int128 reconstruction | 711 ms | 3719 ms |
+| Scheme II — total | 947 ms | 4217 ms |
+
+The 14 GEMMs themselves are only ~1.3 ms; this CPU-reconstruction version is
+dominated by **Int64 residue arithmetic**, **14 host transfers**, and the **CPU
+Int128 Garner reconstruction**.
+
+**On-GPU reconstruction (done — `probe_schemeII_gpu.jl`).** Moved everything to
+the GPU: residues in **Float64** (no Int64), **Int32 Garner** digits on-GPU, and
+the big-integer combine + balanced reduction in a **double-double CUDA kernel**
+(≈106 bits — the FP64 result needs only X's top ~53 bits, and balancing `X−M` in
+dd absorbs the leading cancellation). Correct to full FP64 (relerr 4.7e-16 at
+s=14). This cut Scheme II from ~100× slower to **~2× slower** than Scheme I — but
+**still not a win on this card:**
+
+| Size | native FP64 | Scheme I (43) | Scheme II GPU (14) |
+|------|-------------|---------------|--------------------|
+| 1024³ | 7.6 ms | 9.8 ms | 28.3 ms (0.35× Scheme I) |
+| 2048³ | 61 ms | 63 ms | 120 ms (0.53×) |
+| 4096³ | 415 ms | 326 ms | 521 ms (0.63×) |
+
+Breakdown (2048³): the 14 GEMMs are ~6.6 ms; the cost is **Float64 residue
+passes (~43 ms)**, **Garner (s²=196 elementwise launches, ~20 ms)**, and
+**digit-stacking + dd kernel (~49 ms)**. So Scheme II is entirely
+reconstruction-bound: the GEMM-count win (43→14) is tiny in absolute terms here,
+and the unfused reconstruction swamps it. It improves with size (0.35×→0.63×) and
+would need **heavy kernel fusion** (fuse residue computation, fuse Garner+dd into
+one kernel) to win — which is what the RIKEN reference (GEMMul8) and the papers
+do, and why their 6–7× appears on datacenter cards (A100/GH200/B200) where INT8
+GEMMs dominate and reconstruction is fused. **On the RTX 4060 Ti, Scheme I (all-
+GPU, simple FP64 recombination) remains the faster path.**
+
+### Full `MMul4` (BallMatrix × BallMatrix) — implemented & verified
+
+The probes above enclose the *point* product `mA·mB`. A true `MMul4` (see
+`src/types/MMul/MMul4.jl`) also propagates the **input radii**: its directed
+rounding of `mA·mB` (up for `C2`, down for `C1`) simultaneously captures the
+product's rounding error *and* `rC_input = |mA|·rB + rA·(|mB|+rB)`. The GPU
+version splits these two roles cleanly (`probe_int8_mmul4.jl`):
+
+```
+m     = INT8-Ozaki(mA, mB)                    exact FP64 midpoint  (expensive)
+ρ     = rigorous bound on |m − mA·mB|          (Ozaki truncation + recomb)
+rC_in = upper_bound(|mA|·rB + rA·(|mB|+rB))    FP32 GEMMs, inflated up  (cheap)
+C     = ( m ,  ρ + rC_in )                     rounded up
+```
+
+The midpoint is where accuracy matters (→ exact INT8-Ozaki); `rC_in` only needs
+to be a valid **upper bound**, so it's a single low-precision (FP32, inflated)
+GEMM — the input radii are typically ~1e-16 anyway. (Nice symmetry: TF32, useless
+for the accurate midpoint, is fine here.) **Verified to contain the exact ball
+product** vs 300-bit BigFloat at input-radius levels 0, 1e-12, 1e-8, 1e-4 — the
+ball radius transitions correctly from ρ-dominated (tiny inputs) to
+input-radius-dominated (`5.7e-4` rel at radius 1e-4). With the tight ρ
+(`probe_int8_rigor_tight.jl`), the point-input radius is ~1.1e-14 rel.
+
+## Bottom line & where this pays off
+
+* **Correctness & rigor: established** for the routes tested. Both produce
+  verified enclosures (CuTileExt overlaps CPU `MMul4`; TF32-Ozaki contained by
+  BigFloat truth).
+* **Routes 1 & 2 on the RTX 4060 Ti (and A40): not worth it.** Float64 (Route 1)
+  loses to the multithreaded CPU (no FP64 tensor cores, 1/64 FP32 rate);
+  TF32-Ozaki (Route 2) loses because consumer TF32 is only ~1.5× FP32, so 3–4
+  GEMMs ≈ 3.8×.
+> **Midpoint vs full `MMul4`.** Most benchmarks below time the *midpoint*
+> product `mA·mB` (the expensive GEMM). A full `MMul4` also returns the radius
+> `rC`. The radius is cheap: the midpoint-error part is row/col-sum bounds (no
+> GEMM, since the CRT is exact), and the input-radius part `|mA|·rB+rA·(|mB|+rB)`
+> is ≤2 FP32 GEMMs (only when radii ≠ 0). The *full* GPU `MMul4` built on the port
+> (`probe_gemmul8_mmul4.jl`, verified to contain the exact ball product vs
+> BigFloat) beats CPU `MMul4` by **~6–8×** — see that section. Midpoint-only
+> speedups quoted elsewhere are larger because they omit the (cheap) radius.
+
+* **Route 3 (INT8-Ozaki Scheme I) is a winner — prototyped and validated.**
+  Exact integer tensor-core products make it both rigorous *and* fast. Matches
+  FP64 accuracy with verified BigFloat enclosure; the *midpoint* beats native
+  GPU FP64 (1.1–1.65× at ≥2048³). This reverses Route 1, which lost to the CPU.
+* **Scheme II (CRT): the Julia port of GEMMul8 (`gemmul8_port.jl`) is the fastest.**
+  A hand-rolled on-GPU Garner version was ~2× slower than Scheme I, but porting
+  GEMMul8's *fused* reconstruction (precomputed CRT weights, no Garner) **plus
+  fused residue extraction** brought the *midpoint* to **beat Scheme I at every
+  size (1.18–1.91×)** and native FP64 by up to 2.45×, full FP64. The **full
+  `MMul4`** on it beats CPU `MMul4` by **~6–8×** (verified rigorous).
+* **Datacenter cards** help all routes (A100/H100 add real FP64 tensor cores and
+  ~8× TF32/FP32), but Route 3 (Scheme I)'s advantage does **not** depend on them.
+  Scheme II's advantage *does* — it wins where INT8 GEMMs dominate and the
+  reconstruction is fused (A100/GH200/B200), which is the papers' regime.
+
+### Julia port of RIKEN's GEMMul8 (`gemmul8_port.jl`)
+
+[GEMMul8](https://github.com/RIKEN-RCCS/GEMMul8) (MIT, © 2025- RIKEN R-CCS) is
+the authors' reference Ozaki-II implementation. **`gemmul8_port.jl` is a Julia /
+CUDA.jl port of its INT8 DGEMM path** (the MIT notice is reproduced in the file
+header). Reading the reference pinpointed exactly the fusion our hand-rolled
+Scheme II lacked:
+
+- **No Garner.** Reconstruction is the *direct* CRT with **precomputed weights**
+  `qPᵢ = qᵢ·Pᵢ` baked as double-double. The `hi` part is rounded to a **uniform
+  absolute level** `2^(E−52+⌈log₂ρ⌉)` (E = exponent of P, ρ = Σ⌊pᵢ/2⌋) so the
+  accumulation `Σ qhiᵢ·aᵢ` is **error-free** (lands exactly in 53 bits) — this
+  uniform-absolute truncation (not per-value relative) is the subtle bit.
+- Accumulate with two FMAs/term, then `X = C64f − P·rint(C64f/P)` (rint ⇒ signed,
+  no separate balance step), then the diagonal rescale — **all in one fused
+  per-element kernel** (port of GEMMul8 `invscal_device`).
+
+Two fusions, each ~halving the time, brought it to full FP64 (relerr 4.3e-16,
+s=14) and a clear win at every size:
+- **Fused reconstruction** (precomputed CRT weights + 1 kernel, no Garner):
+  2048³ 120→60 ms; 4096³ 521→268 ms.
+- **Fused residue extraction** (`fused_residues_kernel!`, port of GEMMul8
+  `extract_A_lo`): one pass over A and one over B emit *all* moduli residues
+  (vs 14 passes each). 2048³ 60→35 ms; 4096³ 268→169 ms.
+
+*Midpoint* product timing (the GEMM only):
+
+| Size | native FP64 | Scheme I (43) | GEMMul8-port (14) | vs Scheme I | vs FP64 |
+|------|-------------|---------------|-------------------|-------------|---------|
+| 1024³ | 7.7 ms | 9.4 ms | 7.9 ms | 1.18× | 0.97× |
+| 2048³ | 58 ms | 61 ms | 35 ms | 1.73× | 1.64× |
+| 4096³ | 413 ms | 323 ms | **169 ms** | 1.91× | **2.45×** |
+
+So the midpoint **beats Scheme I at every size** (1.18–1.91×) and native FP64 by
+up to **2.45×**, full FP64. (The paper's 6–7× needs datacenter INT8/FP64 ratios;
+2.45× is the consumer-Ada ceiling here.)
+
+#### Full `MMul4` on the port (`probe_gemmul8_mmul4.jl`)
+
+A *full* `MMul4` = midpoint (port) + radius `ρ_trunc + rC_in`. `ρ_trunc` is the
+input-scaling truncation `|δA|·|mB|+|mA|·|δB|`; since the CRT midpoint is exact,
+`|δA| ≤ 2^(σA−k−1)` is per-row constant, so this is **row/col sums × broadcast,
+no GEMM**. `rC_in = |mA|·rB+rA·(|mB|+rB)` is ≤2 FP32 GEMMs, only when radii ≠ 0.
+**Verified to contain the exact ball product** vs 300-bit BigFloat at input-radius
+levels 0 / 1e-10 / 1e-5 (radius 5.2e-15 rel at zero input radius — FP64-tight).
+
+| Size | CPU `MMul4` | GPU `MMul4` (port) | speedup |
+|------|-------------|--------------------|---------|
+| 1024³ | 87 ms | 13 ms | ~6.6× |
+| 2048³ | 672 ms | 83 ms | ~8× |
+| 4096³ | 2897 ms | 410 ms | ~7× |
+
+So the honest full-`MMul4` win over CPU is **~6–8×** (adding the radius + the
+full-pipeline overhead roughly halves the midpoint-only figure). Still the
+fastest rigorous-capable `MMul4` here, and a *true* ball×ball product.
+
+`num_moduli` is the accuracy/speed knob (SGEMM/CGEMM 2–13, DGEMM/ZGEMM 2–20);
+error is governed by it → boundable for a rigorous radius. Remaining port work:
+add SGEMM and **CGEMM/ZGEMM** (complex, from arXiv:2512.08321); wrap as the
+`MMul4` overload (midpoint via the port + ρ from `num_moduli` + FP32 input-radius
+term).
+
+## Recommended next steps
+
+1. ✅ **DONE — tightened the INT8-Ozaki radius** (`probe_int8_rigor_tight.jl`):
+   per-`i` tail-sum bound in FP32 + rigorous recombination/residual bounds. Radius
+   1.1e-14 rel at T=10, ~20× the true error (the `√K` rigor floor), tighter than a
+   native FP64 `MMul4`.
+2. ✅ **DONE — Scheme II reconstruction ported on-GPU** (`probe_schemeII_gpu.jl`):
+   Float64 residues + Int32 Garner + double-double combine kernel, full FP64,
+   ~2× slower than Scheme I (reconstruction-bound on consumer HW; would need
+   kernel fusion to win — see GEMMul8 below). Remaining Scheme-I pipeline tweaks:
+   group recombination by `i+j`, overlap recombine with the next GEMM (2-stream).
+3. **For production / complex / datacenter, wrap [GEMMul8](https://github.com/RIKEN-RCCS/GEMMul8)**
+   (RIKEN's fused Ozaki-II, incl. CGEMM/ZGEMM) for the midpoint + add the rigorous
+   radius, rather than hand-rolling fused kernels.
+4. **Wrap as a `MMul4` overload** for `Float64`/`Float32` (and complex) ball
+   matrices on `CuArray`, dispatched like the CuTileExt overload; pick `T`/`s`
+   from the requested radius. Add `m,n,k % 4 == 0` padding.
+5. Re-run `bench_mmul4.jl` (Float64, CuTileExt) and `probe_tf32_rigor.jl`
+   (TF32-Ozaki) on an **A100/H100** to confirm the Route-1/2 crossover. The A40
+   on toeplitz is *not* sufficient (GA102 FP64 penalty). Needs Julia ≥ 1.11 for
+   cuTile (toeplitz ships 1.8.1 — ask Leonardo to load a recent Julia).
+6. Keep `CuTileExt.jl` (outer-product, directed-rounding) as the correct,
+   tensor-core-free fallback.
+
+## References
+
+- Ozaki, Uchino, Imamura, *"Ozaki Scheme II: A GEMM-oriented emulation of FP
+  matmul using an integer modular technique"*, arXiv:2504.08009 (2025).
+- Uchino, Ma, Imamura, Ozaki, Gutsche, *"Emulation of Complex Matrix
+  Multiplication based on the Chinese Remainder Theorem"*, arXiv:2512.08321
+  (2025) — CGEMM/ZGEMM on INT8; 4–6.5× over cuBLAS on B200.
+- RIKEN-RCCS, **GEMMul8**, https://github.com/RIKEN-RCCS/GEMMul8 — reference
+  Ozaki-II (CUDA/HIP; SGEMM/DGEMM/CGEMM/ZGEMM; `num_moduli`, `fastmode`).
+
+## Script index (`experiments/cutile_probe/`)
+
+| Script | Purpose |
+|--------|---------|
+| `probe.jl` | Shows tile `mma` ignores `@fpmode` (Up==Dn bitwise). |
+| `probe_elementwise.jl` | Outer-product honors `@fpmode` (one-sided bracketing). |
+| `probe_mmul4.jl` | Full `MMul4` on cuTile validated vs CPU. |
+| `smoke_test.jl` | Extension loads + `*` dispatch overlaps CPU (8 cases). |
+| `bench_mmul4.jl` | Float64 CuTileExt GPU vs CPU benchmark. |
+| `probe_tf32_ozaki.jl` | TF32 engagement + Ozaki accuracy recovery. |
+| `probe_tf32_rigor.jl` | TF32-Ozaki rigorous radius (BigFloat-checked) + timing. |
+| `probe_int8_ozaki.jl` | INT8-Ozaki accuracy vs BigFloat (slice count sweep). |
+| `probe_int8_bench.jl` | INT8-Ozaki vs native FP64 timing (beats FP64 at ≥2048³). |
+| `probe_int8_rigor.jl` | INT8-Ozaki rigorous ball (loose bound), BigFloat check. |
+| `probe_int8_rigor_tight.jl` | Tight radius: per-i tail sums (1.1e-14 rel, ~20× err). |
+| `probe_int8_streams.jl` | Time breakdown; GEMM-stream concurrency (no speedup). |
+| `probe_int8_vs_cpu.jl` | INT8-Ozaki GPU vs CPU FP64 gemm and rigorous CPU MMul4. |
+| `probe_int8_schemeII.jl` | Scheme II (CRT) correctness vs BigFloat (14 gemms → FP64). |
+| `probe_schemeII_bench.jl` | Scheme II GEMM/reconstruction breakdown vs Scheme I (CPU recon). |
+| `probe_schemeII_gpu.jl` | Scheme II with on-GPU double-double CRT (Garner) reconstruction. |
+| `probe_schemeII_gpu_bench.jl` | GPU Scheme II (Garner) vs Scheme I vs native FP64. |
+| `gemmul8_port.jl` | **Julia port of RIKEN GEMMul8** (fused direct-CRT reconstruction). |
+| `gemmul8_bench.jl` | GEMMul8 port vs Scheme I vs native FP64 (beats both at 4096³). |
+| `probe_gemmul8_mmul4.jl` | **Full ball MMul4** on the port (mid+radius); enclosure + vs CPU MMul4 (~6–8×). |
+| `probe_int8_mmul4.jl` | Full GPU MMul4 (ball×ball): INT8 midpoint + FP32 radius. |
+| `issue_draft.md` | Body of cuTile.jl issue #229. |


### PR DESCRIPTION
Rigorous GPU GEMM/SVD extensions, independent of the VBD work on main.

- **CUDAExt** — GPU rigorous BallMatrix product (MMul4) on NVIDIA INT8 tensor cores, a Julia/CUDA.jl port of RIKEN R-CCS's GEMMul8 (Ozaki Scheme II). See `ext/RIGOROUS_GPU_GEMM.md`.
- **CuTileExt** — cuTile-based path.
- Both are weakdep-gated (`CUDA` / `cuTile` + `CUDACore`), so the package precompiles unchanged when CUDA is absent (verified).
- Adds `experiments/cutile_probe/` (research probes/benchmarks) and `CLAUDE.md`.

Branch is additive (no deletions); merges cleanly onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)