### PR TITLE
Document Oishi-MMul kernels as Advanced API; export oishi_MMul

### DIFF
--- a/src/BallArithmetic.jl
+++ b/src/BallArithmetic.jl
@@ -75,6 +75,8 @@ include("types/vector.jl")
 export BallVector
 include("types/triangularize.jl")
 
+export oishi_MMul
+
 include("types/convertpromote.jl")
 include("norm_bounds/rigorous_norm.jl")
 export upper_bound_norm


### PR DESCRIPTION
Salvaged from the stale `codex/review-proceduresmiyajima2010` branch: Advanced-API docstrings on the Oishi 2010 rounding kernels (`oishi_mmul.jl`) + `export oishi_MMul` (already used by `rigorous_residual.jl`). The branch's drifted `docs/*` hunks were dropped. Package precompiles; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)